### PR TITLE
Correct input for repeated form types when running in non-interactive mode

### DIFF
--- a/src/Bridge/Interaction/NonInteractiveRootInteractor.php
+++ b/src/Bridge/Interaction/NonInteractiveRootInteractor.php
@@ -29,7 +29,7 @@ class NonInteractiveRootInteractor implements FormInteractor
         foreach ($form->all() as $child) {
             $config = $child->getConfig();
             $name = $child->getName();
-            if ($config->getType()->getInnerType() instanceof RepeatedType && $input->hasOption('name')) {
+            if ($config->getType()->getInnerType() instanceof RepeatedType && $input->hasOption($name)) {
                 $input->setOption($name, [
                     $config->getOption('first_name') => $input->getOption($name),
                     $config->getOption('second_name') => $input->getOption($name)

--- a/src/Bridge/Interaction/NonInteractiveRootInteractor.php
+++ b/src/Bridge/Interaction/NonInteractiveRootInteractor.php
@@ -6,6 +6,7 @@ use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\CanNotInteractWithF
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormInterface;
 
 class NonInteractiveRootInteractor implements FormInteractor
@@ -22,6 +23,18 @@ class NonInteractiveRootInteractor implements FormInteractor
 
         if ($input->isInteractive()) {
             throw new CanNotInteractWithForm('This interactor only works with non-interactive input');
+        }
+
+        // Make sure to adjust input for repeated types.
+        foreach ($form->all() as $child) {
+            $config = $child->getConfig();
+            $name = $child->getName();
+            if ($config->getType()->getInnerType() instanceof RepeatedType && $input->hasOption('name')) {
+                $input->setOption($name, [
+                    $config->getOption('first_name') => $input->getOption($name),
+                    $config->getOption('second_name') => $input->getOption($name)
+                ]);
+            }
         }
 
         // use the original input as the submitted data


### PR DESCRIPTION
I tried to create a test case but couldn't get Behat to work. :-(

Example code:

``` php
        $builder
            ->add('password', 'repeated', array(
                'type' => 'password',
                'invalid_message' => 'The password fields must match.',
                'options' => array(
                    'label_attr' => array('class' => 'col-sm-3'),
                    'constraints' => array(
                        new NotBlank(),
                        new Length(array('min' => 7, 'max' => 40))
                    )
                ),
                'required' => true,
                'first_options'  => array('label' => 'Admin Password'),
                'second_options' => array('label' => 'Repeat Password'),
                ))
```

It works fine in interactive mode, but for non-interactive mode, this fix is needed.
