### PR TITLE
Show label for time, date, datetime form types if widget is set to single text

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -33,6 +33,8 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function __construct()
     {
+        ini_set('date.timezone', 'GMT');
+
         $kernel = new AppKernel('test', true);
         $this->application = new Application($kernel);
         $this->tester = new ApplicationTester($this->application);

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -33,7 +33,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function __construct()
     {
-        ini_set('date.timezone', 'GMT');
+        ini_set('date.timezone', 'UTC');
 
         $kernel = new AppKernel('test', true);
         $this->application = new Application($kernel);

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -49,8 +49,8 @@ Feature: It is possible to interactively fill in a form from the CLI
           [dateOfBirth] => DateTime Object
           (
               [date] => 2015-03-04 00:00:00.000000
-              [timezone_type] => 2
-              [timezone] => GMT
+              [timezone_type] => 1
+              [timezone] => +00:00
           )
       )
       """

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -36,6 +36,25 @@ Feature: It is possible to interactively fill in a form from the CLI
       This value is too short.
       """
 
+  Scenario: Provide a date as text
+    When I run the command "form:date_of_birth" and I provide as input
+      """
+      2015-03-04[enter]
+      """
+    Then the command has finished successfully
+    And the output should be
+      """
+      Your date of birth [1879-03-14]: Array
+      (
+          [dateOfBirth] => DateTime Object
+          (
+              [date] => 2015-03-04 00:00:00.000000
+              [timezone_type] => 2
+              [timezone] => GMT
+          )
+      )
+      """
+
   Scenario: Select a value
     When I run the command "form:color" and I provide as input
       """

--- a/src/Bridge/Transformer/DateTimeTransformer.php
+++ b/src/Bridge/Transformer/DateTimeTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
+
+use Symfony\Component\Form\FormInterface;
+
+class DateTimeTransformer extends TextTransformer
+{
+    protected function defaultValueFrom(FormInterface $form)
+    {
+        return $form->getViewData();
+    }
+}

--- a/src/Bundle/services.yml
+++ b/src/Bundle/services.yml
@@ -34,6 +34,14 @@ services:
         tags:
             - { name: form_to_question_transformer, form_type: text }
 
+    matthias_symfony_console_form.date_time_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\DateTimeTransformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: time }
+            - { name: form_to_question_transformer, form_type: date }
+            - { name: form_to_question_transformer, form_type: datetime }
+
     matthias_symfony_console_form.password_transformer:
         class: Matthias\SymfonyConsoleForm\Bridge\Transformer\PasswordTransformer
         public: false

--- a/test/Form/Data/Demo.php
+++ b/test/Form/Data/Demo.php
@@ -8,4 +8,5 @@ class Demo
     public $email;
     public $country;
     public $addresses;
+    public $dateOfBirth;
 }

--- a/test/Form/DateOfBirthType.php
+++ b/test/Form/DateOfBirthType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DateOfBirthType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'dateOfBirth',
+                'date',
+                [
+                    'label' => 'Your date of birth',
+                    'data' => new \DateTime('1879-03-14'),
+                    'widget' => 'single_text',
+                ]
+            )->add(
+                'submit',
+                'submit',
+                [
+                    'label' => 'Submit',
+                ]
+            );
+    }
+
+    public function getName()
+    {
+        return 'date_of_birth';
+    }
+}

--- a/test/Form/DemoType.php
+++ b/test/Form/DemoType.php
@@ -51,6 +51,15 @@ class DemoType extends AbstractType
                     ],
                 ]
             )
+            ->add(
+                'dateOfBirth',
+                'date',
+                [
+                    'label' => 'Your date of birth',
+                    'data' => new \DateTime('1879-03-14'),
+                    'widget' => 'single_text',
+                ]
+            )
         ;
     }
 

--- a/test/config.yml
+++ b/test/config.yml
@@ -37,6 +37,13 @@ services:
         tags:
             - { name: console.command }
 
+    date_of_birth_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - date_of_birth
+        tags:
+            - { name: console.command }
+
     demo_form_type:
         class: Matthias\SymfonyConsoleForm\Tests\Form\DemoType
         tags:
@@ -61,6 +68,11 @@ services:
         class: Matthias\SymfonyConsoleForm\Tests\Form\RepeatedPasswordType
         tags:
             - { name: form.type, alias: repeated_password }
+
+    date_of_birth_form_type:
+        class: Matthias\SymfonyConsoleForm\Tests\Form\DateOfBirthType
+        tags:
+            - { name: form.type, alias: date_of_birth }
 
 framework:
     form:


### PR DESCRIPTION
This PR adds ability to display label for `datetime`, `date` and `time` form types with `widget` option specified to `single_text`. The label is still not appearing if `widget` is set to `choice` or `text`. I belive this could be fixed with dedicated interactor - so maybe in next PR.
