### PR TITLE
Fix default name (+ humanize).

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -72,3 +72,17 @@ Feature: It is possible to interactively fill in a form from the CLI
           [color] => blue
       )
       """
+
+  Scenario: Empty label
+    When I run the command "form:empty_label" and I provide as input
+      """
+        empty[enter]
+      """
+    Then the command has finished successfully
+    And the output should be
+      """
+        Field name: Array
+        (
+            [fieldName] => empty
+        )
+      """

--- a/src/Form/FormUtil.php
+++ b/src/Form/FormUtil.php
@@ -63,7 +63,13 @@ class FormUtil
      */
     public static function label(FormInterface $form)
     {
-        return $form->getConfig()->getOption('label', $form->getName());
+        $label = $form->getConfig()->getOption('label');
+
+        if (!$label) {
+            $label = self::humanize($form->getName());
+        }
+
+        return $label;
     }
 
     /**
@@ -74,5 +80,17 @@ class FormUtil
     public static function isCompound(FormInterface $form)
     {
         return $form->getConfig()->getCompound();
+    }
+
+    /**
+     * Copied from Symfony\Component\Form method humanize.
+     *
+     * @param $text
+     *
+     * @return string
+     */
+    private static function humanize($text)
+    {
+        return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $text))));
     }
 }

--- a/test/Form/EmptyLabelType.php
+++ b/test/Form/EmptyLabelType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class EmptyLabelType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'fieldName',
+                TextType::class
+            );
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -42,6 +42,14 @@ services:
         tags:
             - { name: console.command }
 
+    empty_label_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\EmptyLabelType
+            - empty_label
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
To replicate this issue you must remove Matthias\SymfonyConsoleForm\Tests\Form::AddressType 'street' label

Then in the execution php test/console.php form:demo "street" label doesn't appear( result: ":") 

It only affects to FormTypes with data_class option, I don't know why but option['label'] is always set to null
