### PR TITLE
JSON Data option to fill forms + JsonTemplate creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ class Demo
 ```php
 <?php
 
-use Symfony\Component\Console\Command\Command;
+use Matthias\SymfonyConsoleForm\Console\Command\AbstractInteractiveFormHelperCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;
 
-class TestCommand extends Command
+class TestCommand extends AbstractInteractiveFormHelperCommand
 {
-    protected function configure()
+    protected function configureCommand()
     {
         $this->setName('form:demo');
     }
@@ -171,10 +171,16 @@ If you add the `--no-interaction` option when running the command, it will submi
 
 If the submitted data is invalid the command will fail.
 
+## Options
+
+- json-data a way to submit a form at once
+- json-data-file a way to submit a form at once (absolute path required)
+
+You can create a json template to fill a form (or multiple forms in same request) with command `matthias:form:json_template 'NAMESPACE/DemoType' 'NAMESPACE/OTHERType' [...]`
+
 # TODO
 
 - Provide example of stand-alone usage (no need to extend the command)
-- Maybe: provide a way to submit a form at once, possibly using a JSON-encoded array
 - Handle invalid form data (maybe in a loop)
 - Add more functional tests
 - Show form label of root form

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -102,6 +102,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
 
     /**
      * @When /^I run the command "([^"]*)" non\-interactively$/
+     * @When /^I run the command '(.*)' non\-interactively$/
      */
     public function iRunTheCommandNonInteractively($command)
     {

--- a/features/json-non-interactive.feature
+++ b/features/json-non-interactive.feature
@@ -1,0 +1,89 @@
+Feature: It is possible to interactively fill in a form from the CLI
+
+  Scenario: Create a json template
+    When I run the command "matthias:form:json_template 'Matthias\\SymfonyConsoleForm\\Tests\\Form\\RegularFormType'" non-interactively
+    Then the output should contain
+      """
+      {
+        "regular_form": {
+          "password": {
+              "password": {
+                  "first": "password data",
+                  "second": "password data"
+              }
+          },
+          "name": "Matthias",
+          "addresses": [
+              {
+                  "street": "dummy data"
+              }
+          ],
+          "email": "dummy@dummy.com",
+          "country": "AF",
+          "dateOfBirth": "1879-03-14"
+        }
+      }
+      """
+
+  Scenario: Use a json template to fill form
+    When I run the command 'form:regular_form --json-data='{"regular_form":{"password":{"password":{"first":"password data","second":"password data"}},"name":"Matthias","addresses":[{"street":"dummy data"}],"email":"dummy@dummy.com","country":"AF","dateOfBirth":"1879-03-14"}}'' non-interactively
+    Then the output should be
+    """
+    Matthias\SymfonyConsoleForm\Tests\Form\Data\Demo Object
+      (
+    [name] => Matthias
+    [password] => Array
+        (
+            [password] => password data
+        )
+
+    [email] => dummy@dummy.com
+    [country] => AF
+    [addresses] => Array
+        (
+          [0] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Address Object
+            (
+                [street] => dummy data
+            )
+
+        )
+    [dateOfBirth] => DateTime Object
+        (
+            [date] => 1879-03-14 00:00:00.000000
+            [timezone_type] => 1
+            [timezone] => +00:00
+        )
+    )
+      """
+
+  Scenario: Use a json template to fill form loaded by FormHelperCommand
+    When I run the command 'form:regular_form_standard_load --json-data='{"regular_form":{"password":{"password":{"first":"password data","second":"password data"}},"name":"Matthias","addresses":[{"street":"dummy data"}],"email":"dummy@dummy.com","country":"AF","dateOfBirth":"1879-03-14"}}'' non-interactively
+    Then the output should be
+    """
+    Matthias\SymfonyConsoleForm\Tests\Form\Data\Demo Object
+      (
+    [name] => Matthias
+    [password] => Array
+        (
+            [password] => password data
+        )
+
+    [email] => dummy@dummy.com
+    [country] => AF
+    [addresses] => Array
+        (
+          [0] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Address Object
+            (
+                [street] => dummy data
+            )
+
+        )
+    [dateOfBirth] => DateTime Object
+        (
+            [date] => 1879-03-14 00:00:00.000000
+            [timezone_type] => 1
+            [timezone] => +00:00
+        )
+    )
+      """
+

--- a/src/Bridge/Interaction/CompoundInteractor.php
+++ b/src/Bridge/Interaction/CompoundInteractor.php
@@ -10,15 +10,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Form\FormInterface;
 
-class CompoundInteractor implements FormInteractor
+class CompoundInteractor implements FormInteractor, FormJsonTemplateInterface
 {
     /**
-     * @var FormInteractor
+     * @var FormInteractor|FormJsonTemplateInterface
      */
     private $formInteractor;
 
     /**
-     * @param FormInteractor $formInteractor
+     * @param FormInteractor|FormJsonTemplateInterface $formInteractor
      */
     public function __construct(FormInteractor $formInteractor)
     {
@@ -45,15 +45,42 @@ class CompoundInteractor implements FormInteractor
             throw new CanNotInteractWithForm('This interactor only works with interactive input');
         }
 
-        if (!FormUtil::isCompound($form)) {
-            throw new CanNotInteractWithForm('Expected a compound form');
-        }
+        $this->formRequirements($form);
 
         $submittedData = [];
 
         foreach ($form->all() as $name => $field) {
             try {
                 $submittedData[$name] = $this->formInteractor->interactWith($field, $helperSet, $input, $output);
+            } catch (NoNeedToInteractWithForm $exception) {
+                continue;
+            }
+        }
+
+        return $submittedData;
+    }
+
+    private function formRequirements(FormInterface $form)
+    {
+        if (!FormUtil::isCompound($form)) {
+            throw new CanNotInteractWithForm('Expected a compound form');
+        }
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @return mixed
+     */
+    public function getAttributesWithFakeData(FormInterface $form)
+    {
+        $this->formRequirements($form);
+
+        $submittedData = [];
+
+        foreach ($form->all() as $name => $field) {
+            try {
+                $submittedData[$name] = $this->formInteractor->getAttributesWithFakeData($field);
             } catch (NoNeedToInteractWithForm $exception) {
                 continue;
             }

--- a/src/Bridge/Interaction/FieldInteractor.php
+++ b/src/Bridge/Interaction/FieldInteractor.php
@@ -3,6 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Bridge\Interaction;
 
 use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\CanNotInteractWithForm;
+use Matthias\SymfonyConsoleForm\Bridge\Transformer\Exception\CouldNotResolveTransformer;
 use Matthias\SymfonyConsoleForm\Bridge\Transformer\TransformerResolver;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -10,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Form\FormInterface;
 
-class FieldInteractor implements FormInteractor
+class FieldInteractor implements FormInteractor, FormJsonTemplateInterface
 {
     /**
      * @var TransformerResolver
@@ -58,5 +59,19 @@ class FieldInteractor implements FormInteractor
     private function questionHelper(HelperSet $helperSet)
     {
         return $helperSet->get('question');
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @return array
+     */
+    public function getAttributesWithFakeData(FormInterface $form)
+    {
+        try {
+            return $this->transformerResolver->resolveForFakeData($form)->getFakeData($form);
+        } catch (CouldNotResolveTransformer $e) {
+            return 'Unknown type';
+        }
     }
 }

--- a/src/Bridge/Interaction/FormJsonTemplateInterface.php
+++ b/src/Bridge/Interaction/FormJsonTemplateInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Interaction;
+
+use Symfony\Component\Form\FormInterface;
+
+interface FormJsonTemplateInterface
+{
+    /**
+     * @param FormInterface $form
+     *
+     * @return mixed
+     */
+    public function getAttributesWithFakeData(FormInterface $form);
+}

--- a/src/Bridge/Interaction/JsonDataInteractor.php
+++ b/src/Bridge/Interaction/JsonDataInteractor.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Interaction;
+
+use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\CanNotInteractWithForm;
+use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\FormNotReadyForInteraction;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormInterface;
+
+class JsonDataInteractor implements FormInteractor
+{
+    /**
+     * @param FormInterface   $form
+     * @param HelperSet       $helperSet
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @throws Exception\FormNotReadyForInteraction
+     * @throws Exception\CanNotInteractWithForm
+     *
+     * @return InputInterface
+     */
+    public function interactWith(
+        FormInterface $form,
+        HelperSet $helperSet,
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        if (!$form->isRoot()) {
+            throw new CanNotInteractWithForm('This interactor only works with root forms');
+        }
+
+        $jsonString = null;
+
+        if ($jsonDataFile = $input->getOption('json-data-file')) {
+            $fsystem = new Filesystem();
+            if ($fsystem->exists($jsonDataFile)) {
+                $jsonString = file_get_contents($jsonDataFile);
+            }
+        }
+
+        if (!$jsonString && !$jsonString = $input->getOption('json-data')) {
+            throw new CanNotInteractWithForm('json-data or json-data-file option are required');
+        }
+
+        if (!$json = json_decode($jsonString, true)) {
+            throw new FormNotReadyForInteraction('Invalid json format "json-data"');
+        }
+
+        if (!isset($json[$form->getName()])) {
+            throw new CanNotInteractWithForm('The json does not have the attribute concerning the form');
+        }
+
+        return $json[$form->getName()];
+    }
+}

--- a/src/Bridge/Transformer/AbstractTransformer.php
+++ b/src/Bridge/Transformer/AbstractTransformer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormInterface;
 /**
  * Reusable code for FormToQuestionTransformers.
  */
-abstract class AbstractTransformer implements FormToQuestionTransformer
+abstract class AbstractTransformer implements FormToQuestionTransformer, FakeDataTransformerInterface
 {
     /**
      * @param FormInterface $form

--- a/src/Bridge/Transformer/ChoiceTransformer.php
+++ b/src/Bridge/Transformer/ChoiceTransformer.php
@@ -5,6 +5,7 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 use Matthias\SymfonyConsoleForm\Console\Helper\Question\AlwaysReturnKeyOfChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class ChoiceTransformer extends AbstractTransformer
 {
@@ -24,5 +25,22 @@ class ChoiceTransformer extends AbstractTransformer
         }
 
         return $question;
+    }
+
+    public function getFakeData(FormInterface $form)
+    {
+        if ($form->getViewData()) {
+            return $form->getViewData();
+        }
+
+        if ($choices = $form->getConfig()->getOption('choices')) {
+            if (is_array($choices)) {
+                reset($choices);
+
+                return $choices[key($choices)];
+            }
+        }
+
+        return 'Unknown choice';
     }
 }

--- a/src/Bridge/Transformer/DateTransformer.php
+++ b/src/Bridge/Transformer/DateTransformer.php
@@ -4,19 +4,14 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Form\FormInterface;
 
-class DateTimeTransformer extends TextTransformer
+class DateTransformer extends DateTimeTransformer
 {
-    protected function defaultValueFrom(FormInterface $form)
-    {
-        return $form->getViewData();
-    }
-
     public function getFakeData(FormInterface $form)
     {
         if ($form->getViewData()) {
             return $form->getViewData();
         }
 
-        return (new \DateTime())->format('Y-m-d H:m:s');
+        return (new \DateTime())->format('Y-m-d');
     }
 }

--- a/src/Bridge/Transformer/EmailTransformer.php
+++ b/src/Bridge/Transformer/EmailTransformer.php
@@ -4,19 +4,14 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Form\FormInterface;
 
-class DateTimeTransformer extends TextTransformer
+class EmailTransformer extends TextTransformer
 {
-    protected function defaultValueFrom(FormInterface $form)
-    {
-        return $form->getViewData();
-    }
-
     public function getFakeData(FormInterface $form)
     {
         if ($form->getViewData()) {
             return $form->getViewData();
         }
 
-        return (new \DateTime())->format('Y-m-d H:m:s');
+        return 'dummy@dummy.com';
     }
 }

--- a/src/Bridge/Transformer/FakeDataTransformerInterface.php
+++ b/src/Bridge/Transformer/FakeDataTransformerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
+
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Transform the given form (field) to a Question used by the Console Component to interact with the user.
+ */
+interface FakeDataTransformerInterface
+{
+    /**
+     * Used to auto-fill form data used in JsonFormTemplateCommand.
+     *
+     * @param FormInterface $form
+     *
+     * @return mixed
+     */
+    public function getFakeData(FormInterface $form);
+}

--- a/src/Bridge/Transformer/PasswordTransformer.php
+++ b/src/Bridge/Transformer/PasswordTransformer.php
@@ -3,6 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class PasswordTransformer extends TextTransformer
 {
@@ -17,5 +18,15 @@ class PasswordTransformer extends TextTransformer
         $question->setHidden(true);
 
         return $question;
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @return string
+     */
+    public function getFakeData(FormInterface $form)
+    {
+        return 'password data';
     }
 }

--- a/src/Bridge/Transformer/TextTransformer.php
+++ b/src/Bridge/Transformer/TextTransformer.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class TextTransformer extends AbstractTransformer
 {
@@ -15,5 +16,19 @@ class TextTransformer extends AbstractTransformer
     public function transform(Form $form)
     {
         return new Question($this->questionFrom($form), $this->defaultValueFrom($form));
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @return mixed|string
+     */
+    public function getFakeData(FormInterface $form)
+    {
+        if ($form->getViewData()) {
+            return $form->getViewData();
+        }
+
+        return 'dummy data';
     }
 }

--- a/src/Bridge/Transformer/TimeTransformer.php
+++ b/src/Bridge/Transformer/TimeTransformer.php
@@ -4,19 +4,14 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Form\FormInterface;
 
-class DateTimeTransformer extends TextTransformer
+class TimeTransformer extends DateTimeTransformer
 {
-    protected function defaultValueFrom(FormInterface $form)
-    {
-        return $form->getViewData();
-    }
-
     public function getFakeData(FormInterface $form)
     {
         if ($form->getViewData()) {
             return $form->getViewData();
         }
 
-        return (new \DateTime())->format('Y-m-d H:m:s');
+        return (new \DateTime())->format('H:m:s');
     }
 }

--- a/src/Bridge/Transformer/TransformerResolver.php
+++ b/src/Bridge/Transformer/TransformerResolver.php
@@ -15,4 +15,13 @@ interface TransformerResolver
      * @return FormToQuestionTransformer
      */
     public function resolve(FormInterface $form);
+
+    /**
+     * @param FormInterface $form
+     *
+     * @throws CouldNotResolveTransformer
+     *
+     * @return FakeDataTransformerInterface
+     */
+    public function resolveForFakeData(FormInterface $form);
 }

--- a/src/Bridge/Transformer/TypeAncestryBasedTransformerResolver.php
+++ b/src/Bridge/Transformer/TypeAncestryBasedTransformerResolver.php
@@ -31,10 +31,27 @@ class TypeAncestryBasedTransformerResolver implements TransformerResolver
      */
     public function resolve(FormInterface $form)
     {
+        return $this->resolveByInstance($form, FormToQuestionTransformer::class);
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @throws CouldNotResolveTransformer
+     *
+     * @return FakeDataTransformerInterface
+     */
+    public function resolveForFakeData(FormInterface $form)
+    {
+        return $this->resolveByInstance($form, FakeDataTransformerInterface::class);
+    }
+
+    private function resolveByInstance(FormInterface $form, $instanceClass)
+    {
         $types = FormUtil::typeAncestry($form);
 
         foreach ($types as $type) {
-            if (isset($this->transformers[$type])) {
+            if (isset($this->transformers[$type]) && $this->transformers[$type] instanceof $instanceClass) {
                 return $this->transformers[$type];
             }
         }

--- a/src/Bundle/services.yml
+++ b/src/Bundle/services.yml
@@ -42,6 +42,18 @@ services:
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\DateType }
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\DateTimeType }
 
+    matthias_symfony_console_form.time_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\TimeTransformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\TimeType }
+
+    matthias_symfony_console_form.date_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\DateTransformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\DateType }
+
     matthias_symfony_console_form.password_transformer:
         class: Matthias\SymfonyConsoleForm\Bridge\Transformer\PasswordTransformer
         public: false
@@ -55,11 +67,19 @@ services:
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\CountryType }
 
+    matthias_symfony_console_form.email_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\EmailTransformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\EmailType }
+
+
     matthias_symfony_console_form.delegating_interactor:
         class: Matthias\SymfonyConsoleForm\Bridge\Interaction\DelegatingInteractor
         public: false
         calls:
             # more specific interactors (by form type acenstry) should be higher in this list
+            - [addInteractor, ["@matthias_symfony_console_form.json_data_interactor"]]
             - [addInteractor, ["@matthias_symfony_console_form.field_with_no_interaction_interactor"]]
             - [addInteractor, ["@matthias_symfony_console_form.non_interactive_root_interactor"]]
             - [addInteractor, ["@matthias_symfony_console_form.collection_interactor"]]
@@ -75,6 +95,12 @@ services:
     matthias_symfony_console_form.field_with_no_interaction_interactor:
         class: Matthias\SymfonyConsoleForm\Bridge\Interaction\FieldWithNoInteractionInteractor
         public: false
+
+    matthias_symfony_console_form.json_data_interactor:
+        class: Matthias\SymfonyConsoleForm\Bridge\Interaction\JsonDataInteractor
+        public: false
+        arguments:
+            - "@matthias_symfony_console_form.delegating_interactor"
 
     matthias_symfony_console_form.non_interactive_root_interactor:
         class: Matthias\SymfonyConsoleForm\Bridge\Interaction\NonInteractiveRootInteractor
@@ -126,3 +152,11 @@ services:
         arguments:
             - "@form.factory"
             - "@form.registry"
+
+    matthias_symfony_console_form.console_form_json_template:
+        class: Matthias\SymfonyConsoleForm\Console\Command\JsonFormTemplateCommand
+        arguments:
+            - "@form.factory"
+            - "@matthias_symfony_console_form.delegating_interactor"
+        tags:
+            -  { name: console.command }

--- a/src/Console/Command/AbstractInteractiveFormHelperCommand.php
+++ b/src/Console/Command/AbstractInteractiveFormHelperCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractInteractiveFormHelperCommand extends Command
+{
+    abstract protected function configureCommand();
+
+    final protected function configure()
+    {
+        $this->configureCommand();
+
+        foreach (FormConsoleOptions::getBasicOptions() as $inputOption) {
+            $this->addOption(
+                $inputOption->getName(),
+                $inputOption->getShortcut(),
+                $inputOption->isValueOptional() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED,
+                $inputOption->getDescription(),
+                $inputOption->getDefault()
+            );
+        }
+    }
+}

--- a/src/Console/Command/AbstractInteractiveFormHelperContainerAwareCommand.php
+++ b/src/Console/Command/AbstractInteractiveFormHelperContainerAwareCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractInteractiveFormHelperContainerAwareCommand extends Command
+{
+    abstract protected function configureCommand();
+
+    final protected function configure()
+    {
+        $this->configureCommand();
+
+        foreach (FormConsoleOptions::getBasicOptions() as $inputOption) {
+            $this->addOption(
+                $inputOption->getName(),
+                $inputOption->getShortcut(),
+                $inputOption->isValueOptional() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED,
+                $inputOption->getDescription(),
+                $inputOption->getDefault()
+            );
+        }
+    }
+}

--- a/src/Console/Command/FormConsoleOptions.php
+++ b/src/Console/Command/FormConsoleOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Console\Command;
+
+use Symfony\Component\Console\Input\InputOption;
+
+class FormConsoleOptions
+{
+    /**
+     * @return InputOption[]
+     */
+    public static function getBasicOptions()
+    {
+        return [
+            new InputOption('json-data', 'j', InputOption::VALUE_OPTIONAL, 'Submit a form at once (json format)'),
+            new InputOption('json-data-file', null, InputOption::VALUE_OPTIONAL, 'Submit a form at once (json format) from a file'),
+        ];
+    }
+}

--- a/src/Console/Command/JsonFormTemplateCommand.php
+++ b/src/Console/Command/JsonFormTemplateCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Console\Command;
+
+use Matthias\SymfonyConsoleForm\Bridge\Interaction\FormInteractor;
+use Matthias\SymfonyConsoleForm\Bridge\Interaction\FormJsonTemplateInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class JsonFormTemplateCommand extends Command
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var FormJsonTemplateInterface
+     */
+    private $formInteractor;
+
+    /**
+     * @param FormFactoryInterface $formFactory
+     * @param FormInteractor       $formInteractor
+     * @param null                 $name
+     */
+    public function __construct(FormFactoryInterface $formFactory, FormInteractor $formInteractor, $name = null)
+    {
+        $this->formFactory = $formFactory;
+        $this->formInteractor = $formInteractor;
+        parent::__construct($name);
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('matthias:form:json_template')
+            ->setDescription('Displays a json template from a FormType')
+            ->addArgument('forms', InputArgument::IS_ARRAY, 'formType name space')
+            ->addOption('inline', null, InputOption::VALUE_OPTIONAL, 'remove pretty price', false)
+            ->addOption('output-file', null, InputOption::VALUE_OPTIONAL, 'Output file with json result', null)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $formClasses = $input->getArgument('forms');
+        $inlineResultFormat = $input->getOption('inline');
+        $outputFile = $input->getOption('output-file');
+
+        if (count($formClasses) == 0) {
+            throw new \RuntimeException("The input 'forms' are required");
+        }
+
+        $formAttributesArr = [];
+
+        foreach ($formClasses as $formClass) {
+            if (!class_exists($formClass)) {
+                throw new \RuntimeException("Form class '$formClass' doesn't exist");
+            }
+
+            $form = $this->formFactory->create($formClass);
+            $formAttributesArr[$form->getName()] = $this->formInteractor->getAttributesWithFakeData($form);
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$inlineResultFormat) {
+            $successMsg = 'JSON was generated!';
+            $io->success($successMsg);
+        }
+
+        $jsonFormatted = json_encode($formAttributesArr, $inlineResultFormat ? 0 : JSON_PRETTY_PRINT);
+
+        if ($outputFile) {
+            $fsystem = new Filesystem();
+            $fsystem->dumpFile($outputFile, $jsonFormatted);
+
+            if (!$inlineResultFormat) {
+                $output->writeln(sprintf("<info>[file+]</info> %s\n", $outputFile));
+            }
+        }
+
+        $output->writeln($jsonFormatted);
+    }
+}

--- a/src/Console/EventListener/SetInputDefinitionOfFormBasedCommandEventListener.php
+++ b/src/Console/EventListener/SetInputDefinitionOfFormBasedCommandEventListener.php
@@ -3,6 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Console\EventListener;
 
 use Matthias\SymfonyConsoleForm\Console\Command\FormBasedCommand;
+use Matthias\SymfonyConsoleForm\Console\Command\FormConsoleOptions;
 use Matthias\SymfonyConsoleForm\Console\Input\InputDefinitionFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -40,6 +41,11 @@ class SetInputDefinitionOfFormBasedCommandEventListener
         }
 
         $inputDefinition = $this->inputDefinitionFactory->createForFormType($command->formType());
+
+        foreach (FormConsoleOptions::getBasicOptions() as $inputOption) {
+            $inputDefinition->addOption($inputOption);
+        }
+
         $this->setInputDefinition($command, $event->getInput(), $inputDefinition);
     }
 

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -7,6 +7,7 @@ use Matthias\SymfonyConsoleForm\Bridge\Interaction\FormInteractor;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 
 class FormHelper extends Helper
@@ -63,6 +64,14 @@ class FormHelper extends Helper
      */
     private function invalidForm(FormInterface $form)
     {
-        throw new \RuntimeException(sprintf('Invalid data provided: %s', $form->getErrors(true, false)));
+        $msg = "Invalid data provided:\n";
+        $template = '- Form: %1$s, Field: %2$s, Reason: %3$s'."\n";
+
+        /** @var $val FormError */
+        foreach ($form->getErrors(true) as $val) {
+            $msg .= sprintf($template, $form->getName(), $val->getOrigin()->getName(), $val->getMessage());
+        }
+
+        throw new \RuntimeException($msg);
     }
 }

--- a/src/Console/Input/InputDefinitionFactory.php
+++ b/src/Console/Input/InputDefinitionFactory.php
@@ -7,6 +7,8 @@ interface InputDefinitionFactory
     /**
      * @param string|\Symfony\Component\Form\FormTypeInterface $formType
      * @param array                                            &$resources
+     *
+     * @return \Symfony\Component\Console\Input\InputDefinition
      */
     public function createForFormType($formType, array &$resources = []);
 }

--- a/test/Command/RegularFormStandardLoadCommand.php
+++ b/test/Command/RegularFormStandardLoadCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Command;
+
+use Matthias\SymfonyConsoleForm\Console\Command\AbstractInteractiveFormHelperCommand;
+use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;
+use Matthias\SymfonyConsoleForm\Tests\Form\RegularFormType;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RegularFormStandardLoadCommand extends AbstractInteractiveFormHelperCommand
+{
+    protected function configureCommand()
+    {
+        $this
+            ->setName('form:regular_form_standard_load')
+            ->setDescription('This command is created manually like a regular app')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var FormHelper $formHelper */
+        $formHelper = $this->getHelper('form');
+        $formData = $formHelper->interactUsingForm(RegularFormType::class, $input, $output);
+
+        $output->write(print_r($formData, true));
+    }
+}

--- a/test/Form/Data/Demo.php
+++ b/test/Form/Data/Demo.php
@@ -5,6 +5,7 @@ namespace Matthias\SymfonyConsoleForm\Tests\Form\Data;
 class Demo
 {
     public $name;
+    public $password;
     public $email;
     public $country;
     public $addresses;

--- a/test/Form/RegularFormType.php
+++ b/test/Form/RegularFormType.php
@@ -13,12 +13,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Country;
 use Symfony\Component\Validator\Constraints\Email;
 
-class DemoType extends AbstractType
+class RegularFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('password', RepeatedPasswordType::class)
+            ->add(
+                'password',
+                RepeatedPasswordType::class
+            )
             ->add(
                 'name',
                 TextType::class,

--- a/test/config.yml
+++ b/test/config.yml
@@ -50,6 +50,19 @@ services:
         tags:
             - { name: console.command }
 
+    regular_form_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\RegularFormType
+            - regular_form
+        tags:
+            - { name: console.command }
+
+    regular_form_standard_load_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\RegularFormStandardLoadCommand
+        tags:
+            -  { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
### Json Options

Options added for FormBasedCommand (This options are used to fill form at once.)

**--json-data** Load data as input and fill form at once
**--json-data-file** Load data from a file and fill form at once

To normal use for form helper, class AbstractInteractiveFormHelperCommand was created to configure static options.

If you use 3 forms and json data option only fill 1 form, interactor display the others 2 forms to be filled.
### JsonTemplate Command was created

Used to create a json template for multiples forms in the same command.

 `matthias:form:json_template 'NAMESPACE/DemoType' 'NAMESPACE/OTHERType' [...]`

 with options

 **--inline** print json inline and remove messages and pretty json
 **--output-file** json template is saved in a file
