### PR TITLE
Symfony 3.0 createBuilder doesn't accept FormTypeInterface anymore

### DIFF
--- a/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
+++ b/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
@@ -43,7 +43,12 @@ class ConsoleFormWithDefaultValuesAndOptionsFactory implements ConsoleFormFactor
     {
         $options = $this->addDefaultOptions($options);
 
-        $formBuilder = $this->formFactory->createBuilder($formType, null, $options);
+        $class = $formType;
+        if ($class instanceof FormTypeInterface) {
+            $class = get_class($formType);
+        }
+
+        $formBuilder = $this->formFactory->createBuilder($class, null, $options);
 
         foreach ($formBuilder as $name => $childBuilder) {
             /* @var FormBuilderInterface $childBuilder */


### PR DESCRIPTION
Symfony 3.0 createBuilder doesn't accept FormTypeInterface anymore, only string are available

Class was updated with this commit: 
https://github.com/symfony/form/commit/432dcc194d814ace15a6d0496275b50db994e964#diff-88085723772521e7c22837b38a764e22R61
