### PR TITLE
Ask new input when input is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,7 @@ If the submitted data is invalid the command will fail.
 
 - Provide example of stand-alone usage (no need to extend the command)
 - Maybe: provide a way to submit a form at once, possibly using a JSON-encoded array
-- Handle invalid form data (maybe in a loop)
 - Add more functional tests
 - Show form label of root form
 - Show nesting in form hierarchy using breadcrumbs
-- Show counter when looping through a collection form
 - When these things have been provided, release this as a package (or multiple packages for stand-alone use)

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/framework-bundle": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
         "symfony/yaml": "~2.8|~3.0",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "symfony/security": "~2.8|~3.0"
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -82,6 +82,14 @@ class FeatureContext implements Context, SnippetAcceptingContext
         Assertion::contains(StringUtil::trimLines($this->getOutput()), StringUtil::trimLines((string) $expectedOutput));
     }
 
+    /**
+     * @Then /^the output should not contain$/
+     */
+    public function theOutputShouldNotContain(PyStringNode $expectedOutput)
+    {
+        Assertion::false(strpos(StringUtil::trimLines($this->getOutput()), StringUtil::trimLines((string) $expectedOutput)));
+    }
+
     private function getOutput()
     {
         return $this->tester->getDisplay(true);

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -146,3 +146,18 @@ Feature: It is possible to interactively fill in a form from the CLI
             [fieldName] => empty
         )
       """
+
+  Scenario: Provide no value with no default value, value should be asked again
+    When I run the command "form:name_without_default_value" and I provide as input "[enter]Jelmer[enter]"
+    And the output should contain
+      """
+        Your name: Invalid data provided: name:
+      """
+    And the output should contain
+      """
+        ERROR: This value should not be blank
+      """
+    And the output should contain
+      """
+      [name] => Jelmer
+      """

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -161,3 +161,21 @@ Feature: It is possible to interactively fill in a form from the CLI
       """
       [name] => Jelmer
       """
+
+  Scenario: Remove an address from pre filled collection of blocked addresses
+    When I run the command "form:blocked_addresses" and I provide as input
+      """
+        [enter][enter][enter][enter][enter]n[enter][enter]
+      """
+    And the output should contain
+      """
+        [street] => first street
+      """
+    And the output should contain
+      """
+        [street] => second street
+      """
+    And the output should not contain
+      """
+        [street] => third street
+      """

--- a/src/Bridge/Interaction/CollectionInteractor.php
+++ b/src/Bridge/Interaction/CollectionInteractor.php
@@ -69,7 +69,7 @@ class CollectionInteractor implements FormInteractor
         };
 
         foreach ((array) $form->getData() as $key => $entryData) {
-            $this->printEntryHeader($key, $output);
+            $this->printEditEntryHeader($key, $output);
             $prototype->setData($entryData);
 
             $submittedEntry = $this->formInteractor->interactWith($prototype, $helperSet, $input, $output);
@@ -79,7 +79,9 @@ class CollectionInteractor implements FormInteractor
         }
 
         if ($form->getConfig()->getOption('allow_add')) {
+            $key = count($submittedData) - 1;
             while ($this->askIfContinueToAdd($helperSet, $input, $output)) {
+                $this->printAddEntryHeader(++$key, $output);
                 $submittedData[] = $this->formInteractor->interactWith($prototype, $helperSet, $input, $output);
             }
         }
@@ -139,11 +141,27 @@ class CollectionInteractor implements FormInteractor
      * @param int             $entryNumber
      * @param OutputInterface $output
      */
-    private function printEntryHeader($entryNumber, OutputInterface $output)
+    private function printEditEntryHeader($entryNumber, OutputInterface $output)
     {
         $output->writeln(
             strtr(
                 '<fieldset>Edit entry {entryNumber}</fieldset>',
+                [
+                    '{entryNumber}' => $entryNumber,
+                ]
+            )
+        );
+    }
+
+    /**
+     * @param int             $entryNumber
+     * @param OutputInterface $output
+     */
+    private function printAddEntryHeader($entryNumber, OutputInterface $output)
+    {
+        $output->writeln(
+            strtr(
+                '<fieldset>Add entry {entryNumber}</fieldset>',
                 [
                     '{entryNumber}' => $entryNumber,
                 ]

--- a/src/Bridge/Interaction/CollectionInteractor.php
+++ b/src/Bridge/Interaction/CollectionInteractor.php
@@ -64,6 +64,8 @@ class CollectionInteractor implements FormInteractor
 
         $submittedData = [];
         $prototype = $form->getConfig()->getAttribute('prototype');
+        $originalData = $prototype->getData();
+
         $askIfEntryNeedsToBeSubmitted = function ($entryNumber) use ($helperSet, $input, $output) {
             return $this->askIfExistingEntryShouldBeAdded($helperSet, $input, $output, $entryNumber);
         };
@@ -79,6 +81,8 @@ class CollectionInteractor implements FormInteractor
         }
 
         if ($form->getConfig()->getOption('allow_add')) {
+            // reset the prototype
+            $prototype->setData($originalData);
             $key = count($submittedData) - 1;
             while ($this->askIfContinueToAdd($helperSet, $input, $output)) {
                 $this->printAddEntryHeader(++$key, $output);

--- a/src/Bridge/Interaction/CollectionInteractor.php
+++ b/src/Bridge/Interaction/CollectionInteractor.php
@@ -54,8 +54,10 @@ class CollectionInteractor implements FormInteractor
             throw new CanNotInteractWithForm('Expected a "collection" form');
         }
 
-        if (!$form->getConfig()->getOption('allow_add')) {
-            throw new FormNotReadyForInteraction('The "collection" form should have the option "allow_add"');
+        if (!$form->getConfig()->getOption('allow_add') && empty($form->getData())) {
+            throw new FormNotReadyForInteraction(
+                'The "collection" form should have the option "allow_add" or have existing entries'
+            );
         }
 
         $this->printHeader($form, $output);

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -39,12 +39,17 @@ class FormHelper extends Helper
      * @param InputInterface                                   $input
      * @param OutputInterface                                  $output
      * @param array                                            $options
+     * @param mixed                                            $data
      *
      * @return mixed
      */
-    public function interactUsingForm($formType, InputInterface $input, OutputInterface $output, array $options = [])
-    {
-        $data = null;
+    public function interactUsingForm(
+        $formType,
+        InputInterface $input,
+        OutputInterface $output,
+        array $options = [],
+        $data = null
+    ) {
         $validFormFields = [];
 
         do {

--- a/test/Form/BlockedAddressesType.php
+++ b/test/Form/BlockedAddressesType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Address;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class BlockedAddressesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'addresses',
+                CollectionType::class,
+                [
+                    'entry_type' => AddressType::class,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'label' => 'Blocked addresses',
+                ]
+            )
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data' => [
+                    'addresses' => [
+                        new Address('first street'),
+                        new Address('second street'),
+                        new Address('third street'),
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/test/Form/Data/Address.php
+++ b/test/Form/Data/Address.php
@@ -5,4 +5,12 @@ namespace Matthias\SymfonyConsoleForm\Tests\Form\Data;
 class Address
 {
     public $street;
+
+    /**
+     * @param $street
+     */
+    public function __construct($street)
+    {
+        $this->street = $street;
+    }
 }

--- a/test/Form/NameWithoutDefaultValueType.php
+++ b/test/Form/NameWithoutDefaultValueType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class NameWithoutDefaultValueType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'label' => 'Your name',
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ]
+        )->add(
+            'submit',
+            SubmitType::class,
+            [
+                'label' => 'Submit',
+            ]
+        );
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -26,6 +26,14 @@ services:
         tags:
             - { name: console.command }
 
+    blocked_addresses_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\BlockedAddressesType
+            - blocked_addresses
+        tags:
+            - { name: console.command }
+
     color_command:
         class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
         arguments:

--- a/test/config.yml
+++ b/test/config.yml
@@ -18,6 +18,14 @@ services:
         tags:
             - { name: console.command }
 
+    name_without_default_value_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\NameWithoutDefaultValueType
+            - name_without_default_value
+        tags:
+            - { name: console.command }
+
     color_command:
         class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
         arguments:


### PR DESCRIPTION
I altered the FormHelper a bit so it will keep asking input for the invalid form fields until all the data is valid. Then it will return it.

If there is already data for the collection the form will loop over them so you can edit them.
If deleting is allowed you can also choose not to add the item.

To make it easier to follow the current count is also displayed each time an item is edited or added

As a side effect all forms now take predefined data

screenshot of this code in action
<img width="428" alt="screen shot 2017-01-30 at 22 25 22" src="https://cloud.githubusercontent.com/assets/3634654/22442272/0e0db65a-e73b-11e6-8db7-c33bdc8d9c8a.png">

- [x] Ask to fill in the input again when it is invalid
- [x] Allow initial data to be passed to the form
- [x] Handle pre-existing data in collections instead of overwriting them
- [x] Write tests