### PR TITLE
Add PhpStan and implement suggested fixes

### DIFF
--- a/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
+++ b/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
@@ -2,6 +2,7 @@
 
 namespace Matthias\SymfonyConsoleForm\Bridge\FormFactory;
 
+use Matthias\SymfonyConsoleForm\Form\FormUtil;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension;
@@ -37,13 +38,13 @@ class ConsoleFormWithDefaultValuesAndOptionsFactory implements ConsoleFormFactor
      * @param InputInterface           $input
      * @param array                    $options
      *
-     * @return \Symfony\Component\Form\Form
+     * @return \Symfony\Component\Form\FormInterface
      */
     public function create($formType, InputInterface $input, array $options = [])
     {
         $options = $this->addDefaultOptions($options);
 
-        $formBuilder = $this->formFactory->createBuilder($formType, null, $options);
+        $formBuilder = $this->formFactory->createBuilder(FormUtil::formTypeToString($formType), null, $options);
 
         foreach ($formBuilder as $name => $childBuilder) {
             /* @var FormBuilderInterface $childBuilder */

--- a/src/Bridge/Interaction/CollectionInteractor.php
+++ b/src/Bridge/Interaction/CollectionInteractor.php
@@ -6,6 +6,7 @@ use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\CanNotInteractWithF
 use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\FormNotReadyForInteraction;
 use Matthias\SymfonyConsoleForm\Console\Formatter\Format;
 use Matthias\SymfonyConsoleForm\Form\FormUtil;
+use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -122,7 +123,13 @@ class CollectionInteractor implements FormInteractor
      */
     private function questionHelper(HelperSet $helperSet)
     {
-        return $helperSet->get('question');
+        $helper = $helperSet->get('question');
+
+        if (!$helper instanceof QuestionHelper) {
+            throw new RuntimeException('HelperSet does not contain valid QuestionHelper');
+        }
+
+        return $helper;
     }
 
     /**

--- a/src/Bridge/Interaction/FieldInteractor.php
+++ b/src/Bridge/Interaction/FieldInteractor.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Interaction;
 
 use Matthias\SymfonyConsoleForm\Bridge\Interaction\Exception\CanNotInteractWithForm;
 use Matthias\SymfonyConsoleForm\Bridge\Transformer\TransformerResolver;
+use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,6 +58,12 @@ class FieldInteractor implements FormInteractor
      */
     private function questionHelper(HelperSet $helperSet)
     {
-        return $helperSet->get('question');
+        $helper = $helperSet->get('question');
+
+        if (!$helper instanceof QuestionHelper) {
+            throw new RuntimeException('HelperSet does not contain valid QuestionHelper');
+        }
+
+        return $helper;
     }
 }

--- a/src/Bridge/Transformer/ChoiceTransformer.php
+++ b/src/Bridge/Transformer/ChoiceTransformer.php
@@ -4,16 +4,16 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Matthias\SymfonyConsoleForm\Console\Helper\Question\AlwaysReturnKeyOfChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class ChoiceTransformer extends AbstractTransformer
 {
     /**
-     * @param Form $form
+     * @param FormInterface $form
      *
      * @return Question
      */
-    public function transform(Form $form)
+    public function transform(FormInterface $form)
     {
         $formView = $form->createView();
 

--- a/src/Bridge/Transformer/FormToQuestionTransformer.php
+++ b/src/Bridge/Transformer/FormToQuestionTransformer.php
@@ -3,7 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * Transform the given form (field) to a Question used by the Console Component to interact with the user.
@@ -11,9 +11,9 @@ use Symfony\Component\Form\Form;
 interface FormToQuestionTransformer
 {
     /**
-     * @param Form $form
+     * @param FormInterface $form
      *
      * @return Question
      */
-    public function transform(Form $form);
+    public function transform(FormInterface $form);
 }

--- a/src/Bridge/Transformer/PasswordTransformer.php
+++ b/src/Bridge/Transformer/PasswordTransformer.php
@@ -2,16 +2,17 @@
 
 namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
-use Symfony\Component\Form\Form;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Form\FormInterface;
 
 class PasswordTransformer extends TextTransformer
 {
     /**
-     * @param Form $form
+     * @param FormInterface $form
      *
      * @return Question
      */
-    public function transform(Form $form)
+    public function transform(FormInterface $form)
     {
         $question = parent::transform($form);
         $question->setHidden(true);

--- a/src/Bridge/Transformer/TextTransformer.php
+++ b/src/Bridge/Transformer/TextTransformer.php
@@ -3,16 +3,16 @@
 namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class TextTransformer extends AbstractTransformer
 {
     /**
-     * @param Form $form
+     * @param FormInterface $form
      *
      * @return Question
      */
-    public function transform(Form $form)
+    public function transform(FormInterface $form)
     {
         return new Question($this->questionFrom($form), $this->defaultValueFrom($form));
     }

--- a/src/Console/EventListener/RegisterHelpersEventListener.php
+++ b/src/Console/EventListener/RegisterHelpersEventListener.php
@@ -3,6 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Console\EventListener;
 
 use Matthias\SymfonyConsoleForm\Console\Helper\HelperCollection;
+use RuntimeException;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
 class RegisterHelpersEventListener
@@ -25,7 +26,13 @@ class RegisterHelpersEventListener
      */
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
-        $helperSet = $event->getCommand()->getHelperSet();
+        $command = $event->getCommand();
+
+        if (null === $command) {
+            throw new RuntimeException('Received ConsoleCommandEvent without Command instance!');
+        }
+
+        $helperSet = $command->getHelperSet();
 
         $this->helperCollection->addTo($helperSet);
     }

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -71,7 +71,7 @@ class FormHelper extends Helper
             if (!$form->isValid()) {
                 $output->write(sprintf('Invalid data provided: %s', $form->getErrors(true, false)));
                 array_map(
-                    function (FormInterface $formField) use ($form, &$validFormFields) {
+                    function (FormInterface $formField) use (&$validFormFields) {
                         if ($formField->isValid()) {
                             $validFormFields[] = $formField->getName();
                         }

--- a/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
+++ b/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
@@ -23,9 +23,9 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
     private $_errorMessage = 'Value "%s" is invalid';
 
     /**
-     * @param string $question The question to ask to the user
-     * @param array  $choices  The list of available choices
-     * @param mixed  $default  The default answer to return
+     * @param string $question    The question to ask to the user
+     * @param array  $choiceViews The list of available choices
+     * @param mixed  $default     The default answer to return
      */
     public function __construct($question, array $choiceViews, $default = null)
     {

--- a/src/Console/Input/CachedInputDefinitionFactory.php
+++ b/src/Console/Input/CachedInputDefinitionFactory.php
@@ -36,7 +36,7 @@ class CachedInputDefinitionFactory implements InputDefinitionFactory
 
     /**
      * @param string|\Symfony\Component\Form\FormTypeInterface $formType
-     * @param array                                            &$resources
+     * @param array                                            $resources
      *
      * @return mixed
      */
@@ -82,7 +82,7 @@ class CachedInputDefinitionFactory implements InputDefinitionFactory
     /**
      * @param string|\Symfony\Component\Form\FormTypeInterface $formType
      * @param ConfigCache                                      $cache
-     * @param array                                            &$resources
+     * @param array                                            $resources
      *
      * @return \Symfony\Component\Console\Input\InputDefinition
      */

--- a/src/Console/Input/FormBasedInputDefinitionFactory.php
+++ b/src/Console/Input/FormBasedInputDefinitionFactory.php
@@ -27,7 +27,7 @@ class FormBasedInputDefinitionFactory implements InputDefinitionFactory
 
     /**
      * @param string|\Symfony\Component\Form\FormTypeInterface $formType
-     * @param array                                            &$resources
+     * @param array                                            $resources
      *
      * @return InputDefinition
      */
@@ -35,7 +35,7 @@ class FormBasedInputDefinitionFactory implements InputDefinitionFactory
     {
         $resources[] = new FileResource(__FILE__);
 
-        $form = $this->formFactory->create($formType);
+        $form = $this->formFactory->create(FormUtil::formTypeToString($formType));
 
         $actualFormType = $form->getConfig()->getType()->getInnerType();
         $reflection = new \ReflectionObject($actualFormType);

--- a/src/Console/Input/InputDefinitionFactory.php
+++ b/src/Console/Input/InputDefinitionFactory.php
@@ -6,7 +6,7 @@ interface InputDefinitionFactory
 {
     /**
      * @param string|\Symfony\Component\Form\FormTypeInterface $formType
-     * @param array                                            &$resources
+     * @param array                                            $resources
      */
     public function createForFormType($formType, array &$resources = []);
 }

--- a/src/Form/FormUtil.php
+++ b/src/Form/FormUtil.php
@@ -2,7 +2,9 @@
 
 namespace Matthias\SymfonyConsoleForm\Form;
 
+use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\ResolvedFormTypeInterface;
 
 class FormUtil
@@ -22,7 +24,7 @@ class FormUtil
 
     /**
      * @param ResolvedFormTypeInterface|null $formType
-     * @param array                          &$types
+     * @param array                          $types
      */
     public static function typeAncestryForType(ResolvedFormTypeInterface $formType = null, array &$types)
     {
@@ -83,9 +85,33 @@ class FormUtil
     }
 
     /**
+     * @param FormTypeInterface|string $formType
+     *
+     * @return string
+     */
+    public static function formTypeToString($formType)
+    {
+        if ($formType instanceof FormTypeInterface) {
+            return get_class($formType);
+        }
+
+        if (is_string($formType)) {
+            return $formType;
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Unable to determine form type for %s. Expected string or instance of %s',
+                is_object($formType) ? get_class($formType) : gettype($formType),
+                FormInterface::class
+            )
+        );
+    }
+
+    /**
      * Copied from Symfony\Component\Form method humanize.
      *
-     * @param $text
+     * @param string $text
      *
      * @return string
      */


### PR DESCRIPTION
There is one error that is not easy to fix regarding the `NonInteractiveRootInteractor` that calls `setOption` on `InputInterface` with an array, which is not allowed. But to fix this the entire structure of how FormInteractors work need to be reviewed. Is this something you would be interested in?

Also, this is a breaking change as it changes the signature of the Transformers, so if anyone has extended those it will break for them.