### PR TITLE
"matthias_symfony_console_form.delegating_interactor" has a dependency on a non-existent service "translator" fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require": {
         "php": ">=7.0",
         "symfony/form": "~3.0|~4.0",
-        "symfony/console": "~3.0|~4.0"
+        "symfony/console": "~3.0|~4.0",
+        "symfony/translation": "~3.0|~4.0"
     },
     "require-dev": {
         "beberlei/assert": "~2.1",


### PR DESCRIPTION
At installing this library in current version of `symfony/skeleton` project, it causes error: 
```
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:
"matthias_symfony_console_form.delegating_interactor" has a dependency on a non-existent service "translator"
```
which means every child of `@matthias_symfony_console_form.abstract_transformer` needs this service, but it not installed by default. I think the most correct way is to add `translator` into library requirements.