### PR TITLE
Prevent infinite loop on errors not related to the form fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS='--tags="~symfony3.4"'
+      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS=--tags="~symfony3.4"
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS=--tags='~symfony3.4'
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1
@@ -23,6 +23,6 @@ install:
 
 script:
   - vendor/bin/php-cs-fixer fix -v --diff --dry-run
-  - vendor/bin/behat
+  - vendor/bin/behat $BEHAT_ARGS
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS=--tags="~symfony3.4"
+      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS='--tags=~symfony3.4'
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
 
 script:
   - vendor/bin/php-cs-fixer fix -v --diff --dry-run
-  - vendor/bin/behat $BEHAT_ARGS
+  - vendor/bin/behat "$BEHAT_ARGS"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS=--tags='~symfony3.4'
+      env: SYMFONY_VERSION=3.0.* BEHAT_ARGS='--tags="~symfony3.4"'
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -207,3 +207,19 @@ Feature: It is possible to interactively fill in a form from the CLI
           [price] => 10.95
       )
       """
+
+  Scenario: Secret required field
+    When I run the command "form:secret_required_field" and I provide as input
+      """
+      Jelmer[enter]
+      """
+    Then the command was not successful
+    And the output should contain
+      """
+        Invalid data provided: ERROR: This value should not be blank.
+      """
+    And the output should contain
+      """
+        [RuntimeException]
+        Errors out of the form's scope - do you have validation constraints on properties not used in the form?
+      """

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -221,5 +221,5 @@ Feature: It is possible to interactively fill in a form from the CLI
     And the output should contain
       """
         [RuntimeException]
-        Errors out of the form's scope - do you have validation constraints on properties not used in the form?
+        Errors out of the form's scope - do you have validation constraints on properties not used in the form? (Violations on unused fields: data.fieldNotUsedInTheForm)
       """

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -73,7 +73,7 @@ class FormHelper extends Helper
                 $formErrors = $form->getErrors(true, false);
                 $output->write(sprintf('Invalid data provided: %s', $formErrors));
                 if ($this->noErrorsCanBeFixed($formErrors)) {
-                    throw new \RuntimeException('Errors out of the form\'s scope - do you have validation constraints on properties not exposed to the form?');
+                    throw new \RuntimeException('Errors out of the form\'s scope - do you have validation constraints on properties not used in the form?');
                 }
                 array_map(
                     function (FormInterface $formField) use (&$validFormFields) {

--- a/test/Command/PrintFormDataCommand.php
+++ b/test/Command/PrintFormDataCommand.php
@@ -18,7 +18,7 @@ class PrintFormDataCommand extends DynamicFormBasedCommand
             }
 
             return $data;
-        }, $formData);
+        }, (array)$formData);
 
         $output->write(print_r($printData, true));
     }

--- a/test/Form/Data/SecretRequiredField.php
+++ b/test/Form/Data/SecretRequiredField.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form\Data;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SecretRequiredField
+{
+    /**
+     * @Assert\NotBlank()
+     */
+    public $name;
+
+    /**
+     * @Assert\NotBlank()
+     */
+    public $fieldNotUsedInTheForm;
+}

--- a/test/Form/SecretRequiredFieldType.php
+++ b/test/Form/SecretRequiredFieldType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\SecretRequiredField;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+
+class SecretRequiredFieldType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'label' => 'Your name',
+            ]
+        );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => SecretRequiredField::class,
+        ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -90,6 +90,14 @@ services:
         tags:
             - { name: console.command }
 
+    secret_required_field_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\SecretRequiredFieldType
+            - secret_required_field
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
Scenario: I define

* model `MyModel` with two properties, both with validation constraints (e.g. `NotBlank`)
* form type `MyType`, with `MyModel` as data class, but exposing just one of it's two properties
* command interacting using `MyType` like this `$this->getHelper('form')->interactUsingForm(MyType::class, $input, $output);`

Subsequently I run the command. Once I successfully fill the one form field, an infinite loop occurs, endlessly printing

```
Invalid data provided: ERROR: This value should not be blank.
Invalid data provided: ERROR: This value should not be blank.
Invalid data provided: ERROR: This value should not be blank.
Invalid data provided: ERROR: This value should not be blank.
```

That's because the form is invalid (the model instance has a validation error on the unexposed property), but there are no more fields in the form to offer for editation.

My PR detects this situation and throws an error if it occurs.