### PR TITLE
Igneus fix infinite loop on unedited field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
-    - php: 7.0
       env: SYMFONY_VERSION=3.4.*
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION=4.0.*
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -24,18 +24,18 @@
     },
     "require": {
         "php": ">=7.0",
-        "symfony/form": "~3.0|~4.0",
-        "symfony/console": "~3.0|~4.0",
-        "symfony/translation": "~3.0|~4.0"
+        "symfony/form": "~3.4|~4.0",
+        "symfony/console": "~3.4|~4.0",
+        "symfony/translation": "~3.4|~4.0"
     },
     "require-dev": {
         "beberlei/assert": "~2.1",
         "behat/behat": "~3.0",
         "friendsofphp/php-cs-fixer": "^1.10|^2.2",
-        "symfony/finder": "~3.0|~4.0",
-        "symfony/framework-bundle": "~3.0|~4.0",
-        "symfony/validator": "~3.0|~4.0",
-        "symfony/yaml": "~3.0|~4.0",
-        "symfony/security": "~3.0|~4.0"
+        "symfony/finder": "~3.4|~4.0",
+        "symfony/framework-bundle": "~3.4|~4.0",
+        "symfony/validator": "~3.4|~4.0",
+        "symfony/yaml": "~3.4|~4.0",
+        "symfony/security": "~3.4|~4.0"
     }
 }

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -207,3 +207,19 @@ Feature: It is possible to interactively fill in a form from the CLI
           [price] => 10.95
       )
       """
+
+  Scenario: Secret required field
+    When I run the command "form:secret_required_field" and I provide as input
+      """
+      Jelmer[enter]
+      """
+    Then the command was not successful
+    And the output should contain
+      """
+        Invalid data provided: ERROR: This value should not be blank.
+      """
+    And the output should contain
+      """
+        [RuntimeException]
+        Errors out of the form's scope - do you have validation constraints on properties not used in the form?
+      """

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -221,5 +221,5 @@ Feature: It is possible to interactively fill in a form from the CLI
     And the output should contain
       """
         [RuntimeException]
-        Errors out of the form's scope - do you have validation constraints on properties not used in the form?
+        Errors out of the form's scope - do you have validation constraints on properties not used in the form? (Violations on unused fields: data.fieldNotUsedInTheForm)
       """

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -73,7 +73,7 @@ class FormHelper extends Helper
                 $formErrors = $form->getErrors(true, false);
                 $output->write(sprintf('Invalid data provided: %s', $formErrors));
                 if ($this->noErrorsCanBeFixed($formErrors)) {
-                    throw new \RuntimeException('Errors out of the form\'s scope - do you have validation constraints on properties not exposed to the form?');
+                    throw new \RuntimeException('Errors out of the form\'s scope - do you have validation constraints on properties not used in the form?');
                 }
                 array_map(
                     function (FormInterface $formField) use (&$validFormFields) {

--- a/test/Command/PrintFormDataCommand.php
+++ b/test/Command/PrintFormDataCommand.php
@@ -18,7 +18,7 @@ class PrintFormDataCommand extends DynamicFormBasedCommand
             }
 
             return $data;
-        }, $formData);
+        }, (array)$formData);
 
         $output->write(print_r($printData, true));
     }

--- a/test/Form/Data/SecretRequiredField.php
+++ b/test/Form/Data/SecretRequiredField.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form\Data;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SecretRequiredField
+{
+    /**
+     * @Assert\NotBlank()
+     */
+    public $name;
+
+    /**
+     * @Assert\NotBlank()
+     */
+    public $fieldNotUsedInTheForm;
+}

--- a/test/Form/SecretRequiredFieldType.php
+++ b/test/Form/SecretRequiredFieldType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\SecretRequiredField;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+
+class SecretRequiredFieldType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'label' => 'Your name',
+            ]
+        );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => SecretRequiredField::class,
+        ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -90,6 +90,14 @@ services:
         tags:
             - { name: console.command }
 
+    secret_required_field_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\SecretRequiredFieldType
+            - secret_required_field
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
Everything about @igneus's work (#33) runs well in 3.4 and 4, but not in 3.0. However, 3.0 is no longer supported by the Symfony team anyway, so it makes sense to drop support in this library too.

This closes #33.