### PR TITLE
support ChoiceType with data which don't support conversion to string

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -223,3 +223,24 @@ Feature: It is possible to interactively fill in a form from the CLI
         [RuntimeException]
         Errors out of the form's scope - do you have validation constraints on properties not used in the form? (Violations on unused fields: data.fieldNotUsedInTheForm)
       """
+
+  Scenario: Choice with options which cannot be converted to string
+    When I run the command "form:unstringable_choices" and I provide as input
+      """
+      1[enter]
+      """
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Select address:
+        [0] 10 Downing Street
+        [1] 1600 Pennsylvania Ave NW
+        [2] 55 Rue du Faubourg Saint-Honoré
+       > Array
+      (
+        [address] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Address Object
+          (
+            [street] => 1600 Pennsylvania Ave NW
+          )
+      )
+      """

--- a/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
+++ b/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
@@ -118,7 +118,11 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
         foreach ($this->choiceViews as $choiceView) {
             $label = $choiceView->label;
             if ($choiceView->data != $choiceView->value) {
-                $label .= ' (<comment>'.$choiceView->data.'</comment>)';
+                try {
+                    $label .= ' (<comment>' . $choiceView->data . '</comment>)';
+                } catch (\ErrorException $exception) {
+                    // data cannot be converted to string - do nothing
+                }
             }
 
             $choices[$choiceView->value] = $label;
@@ -136,7 +140,11 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
 
         foreach ($this->choiceViews as $choiceView) {
             $autocompleteValues[] = $choiceView->value;
-            $autocompleteValues[] = $choiceView->data;
+            try {
+                $autocompleteValues[] = (string)$choiceView->data;
+            } catch (\ErrorException $exception) {
+                // data cannot be converted to string - do nothing
+            }
             $autocompleteValues[] = $choiceView->label;
         }
 

--- a/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
+++ b/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
@@ -117,12 +117,9 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
         $choices = [];
         foreach ($this->choiceViews as $choiceView) {
             $label = $choiceView->label;
-            if ($choiceView->data != $choiceView->value) {
-                try {
-                    $label .= ' (<comment>' . $choiceView->data . '</comment>)';
-                } catch (\ErrorException $exception) {
-                    // data cannot be converted to string - do nothing
-                }
+            $data = $choiceView->data;
+            if ($data != $choiceView->value && $this->canBeConvertedToString($data)) {
+                $label .= ' (<comment>' . $data . '</comment>)';
             }
 
             $choices[$choiceView->value] = $label;
@@ -140,11 +137,12 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
 
         foreach ($this->choiceViews as $choiceView) {
             $autocompleteValues[] = $choiceView->value;
-            try {
-                $autocompleteValues[] = (string)$choiceView->data;
-            } catch (\ErrorException $exception) {
-                // data cannot be converted to string - do nothing
+
+            $data = $choiceView->data;
+            if ($this->canBeConvertedToString($data)) {
+                $autocompleteValues[] = (string)$data;
             }
+
             $autocompleteValues[] = $choiceView->label;
         }
 
@@ -163,5 +161,14 @@ class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
                 throw new \InvalidArgumentException('Only a flat choice hierarchy is supported');
             }
         }
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    private function canBeConvertedToString($value)
+    {
+        return null === $value || is_scalar($value) || (\is_object($value) && method_exists($value, '__toString'));
     }
 }

--- a/test/Form/UnstringableChoicesType.php
+++ b/test/Form/UnstringableChoicesType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Address;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Demonstrates handling of choice data which does not support conversion to string (Address has no __toString())
+ */
+class UnstringableChoicesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('address', ChoiceType::class, [
+                'label' => 'Select address',
+                'choices' => [
+                    new Address('10 Downing Street'),
+                    new Address('1600 Pennsylvania Ave NW'),
+                    new Address('55 Rue du Faubourg Saint-Honoré'),
+                ],
+                'choice_label' => function (Address $address) {
+                    return $address->street;
+                },
+            ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -98,6 +98,14 @@ services:
         tags:
             - { name: console.command }
 
+    unstringable_choices_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\UnstringableChoicesType
+            - unstringable_choices
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
If an object which cannot be converted to string (i.e. has no `__toString()`) is used as data in a `ChoiceType` (or, probably more frequently, `EntityType`) form field, an exception is thrown - despite of the field configuration containing correct `choice_label` setting. This PR fixes the issue.