### PR TITLE
Prevent infinite loop on invalid non-interactive input

### DIFF
--- a/features/non-interactive.feature
+++ b/features/non-interactive.feature
@@ -28,3 +28,16 @@ Feature: It is possible to interactively fill in a form from the CLI
     Options:
      --password
     """
+
+  Scenario: Provide invalid value
+    When I run the command "form:color --color='invalid color'" non-interactively
+    Then the command was not successful
+    And the output should contain
+    """
+    Invalid data provided: color:
+      ERROR: This value is not valid.
+    """
+    And the output should contain
+    """
+    There were form errors.
+    """

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -90,6 +90,10 @@ class FormHelper extends Helper
                     },
                     $form->all()
                 );
+
+                if (!$input->isInteractive()) {
+                    throw new \RuntimeException('There were form errors.');
+                }
             }
         } while (!$form->isValid());
 


### PR DESCRIPTION
Reasoning behind this PR:
the contract of `FormHelper::interactUsingForm()` is that it always returns valid form data. But in non-interactive mode there is no way to fix invalid input, hence the contract cannot be fulfilled and we should throw an exception instead of returning a value.

It could be worth introducing a specific exception type for this case, as invalid input in non-interactive mode is a situation which some developers will want to handle (unlike the situation with validation errors outside the form's scope, which only results from a programming error). But for now I'm just throwing a generic `RuntimeException` and waiting for your feedback.