### PR TITLE
Add transformer for CheckboxType

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -223,3 +223,31 @@ Feature: It is possible to interactively fill in a form from the CLI
         [RuntimeException]
         Errors out of the form's scope - do you have validation constraints on properties not used in the form? (Violations on unused fields: data.fieldNotUsedInTheForm)
       """
+
+  Scenario: Checkbox field - answer yes
+    When I run the command "form:coffee" and I provide as input
+    """
+    y[enter]
+    """
+    Then the command has finished successfully
+    And the output should be
+    """
+    Do you want milk in your coffee?: Array
+    (
+        [milk] => 1
+    )
+    """
+
+  Scenario: Checkbox field - answer no
+    When I run the command "form:coffee" and I provide as input
+    """
+    n[enter]
+    """
+    Then the command has finished successfully
+    And the output should be
+    """
+    Do you want milk in your coffee?: Array
+    (
+        [milk] =>
+    )
+    """

--- a/src/Bridge/Transformer/CheckboxTransformer.php
+++ b/src/Bridge/Transformer/CheckboxTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
+
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Form\FormInterface;
+
+class CheckboxTransformer extends AbstractTransformer
+{
+    /**
+     * @param FormInterface $form
+     *
+     * @return Question
+     */
+    public function transform(FormInterface $form)
+    {
+        return new ConfirmationQuestion($this->questionFrom($form), $this->defaultValueFrom($form));
+    }
+}

--- a/src/Bundle/services.yml
+++ b/src/Bundle/services.yml
@@ -70,6 +70,13 @@ services:
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\CountryType }
 
+    matthias_symfony_console_form.checkbox_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\CheckboxTransformer
+        parent: matthias_symfony_console_form.abstract_transformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\CheckboxType }
+
     matthias_symfony_console_form.delegating_interactor:
         class: Matthias\SymfonyConsoleForm\Bridge\Interaction\DelegatingInteractor
         public: false

--- a/test/Form/CoffeeMilkType.php
+++ b/test/Form/CoffeeMilkType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Demonstrates use of CheckboxType.
+ */
+class CoffeeMilkType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('milk', CheckboxType::class, [
+                'label' => 'Do you want milk in your coffee?',
+            ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -98,6 +98,14 @@ services:
         tags:
             - { name: console.command }
 
+    coffee_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\CoffeeMilkType
+            - coffee
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
`CheckboxType` is currently unsupported (`Matthias\SymfonyConsoleForm\Bridge\Transformer\Exception\CouldNotResolveTransformer` thrown), this PR adds an appropriate transformer.