### PR TITLE
ChoiceType Questions fix for Symfony 6

### DIFF
--- a/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
+++ b/src/Console/Helper/Question/AlwaysReturnKeyOfChoiceQuestion.php
@@ -42,7 +42,7 @@ final class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
     /**
      * @param bool $multiselect
      */
-    public function setMultiselect($multiselect)
+    public function setMultiselect(bool $multiselect): static
     {
         $this->_multiselect = $multiselect;
 
@@ -52,7 +52,7 @@ final class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
     /**
      * @param string $errorMessage
      */
-    public function setErrorMessage($errorMessage)
+    public function setErrorMessage(string $errorMessage): static
     {
         $this->_errorMessage = $errorMessage;
 
@@ -60,9 +60,9 @@ final class AlwaysReturnKeyOfChoiceQuestion extends ChoiceQuestion
     }
 
     /**
-     * @return callable
+     * @return callable|null
      */
-    public function getValidator()
+    public function getValidator(): ?callable
     {
         return function ($selected) {
             // Collapse all spaces.


### PR DESCRIPTION
Method definitions seem to have changed in Symfony. When using forms with ChoiceType fields, the form errors.
Minor update to make the function type definitions consistent.
Please ignore if I made a mistake as this is my first time contributing