### PR TITLE
fix fatal error when using an object as default value in ChoiceType

### DIFF
--- a/src/Bridge/Transformer/ChoiceTransformer.php
+++ b/src/Bridge/Transformer/ChoiceTransformer.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
 
 use Matthias\SymfonyConsoleForm\Console\Helper\Question\AlwaysReturnKeyOfChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormInterface;
 
 final class ChoiceTransformer extends AbstractTransformer
@@ -19,5 +20,22 @@ final class ChoiceTransformer extends AbstractTransformer
         }
 
         return $question;
+    }
+
+    protected function defaultValueFrom(FormInterface $form)
+    {
+        $defaultValue = parent::defaultValueFrom($form);
+
+        // $defaultValue could be an object
+        // Let's find out what form computed to be its view representation
+        $formView = $form->createView();
+        $defaultValueFromChoiceView = \array_reduce(
+            $formView->vars['choices'],
+            static fn(
+                ?string $carry,
+                ChoiceView $choiceView
+            ): ?string => (null === $carry && $choiceView->data === $defaultValue) ? $choiceView->value : $carry
+        );
+        return $defaultValueFromChoiceView ?? $defaultValue;
     }
 }

--- a/src/Bridge/Transformer/ChoiceTransformer.php
+++ b/src/Bridge/Transformer/ChoiceTransformer.php
@@ -31,10 +31,10 @@ final class ChoiceTransformer extends AbstractTransformer
         $formView = $form->createView();
         $defaultValueFromChoiceView = \array_reduce(
             $formView->vars['choices'],
-            static fn(
+            static fn (
                 ?string $carry,
                 ChoiceView $choiceView
-            ): ?string => (null === $carry && $choiceView->data === $defaultValue) ? $choiceView->value : $carry
+            ): ?string => ($carry === null && $choiceView->data === $defaultValue) ? $choiceView->value : $carry
         );
         return $defaultValueFromChoiceView ?? $defaultValue;
     }


### PR DESCRIPTION
This fixes a fatal error when you use a `ChoiceType`/`EntityType` with an object (which has no `__toString()`) as child default value.
Without this change, you see this error:
```Object of class X could not be converted to string```
Because the library tries to cast to `string` the object to print it in the console like:
```Question [defaultValueAsObject] : ```