### PR TITLE
Add Symfony form "help" option

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -169,6 +169,20 @@ Feature: It is possible to interactively fill in a form from the CLI
         )
       """
 
+  Scenario: Help message
+    When I run the command "form:help_message" and I provide as input
+      | Input |
+      | empty |
+    Then the command has finished successfully
+    And the output should be
+      """
+        Restricted to be ACME Inc.
+        Company: Array
+        (
+            [fieldCompany] => empty
+        )
+      """
+
   Scenario: Translatable label
     When I run the command "form:translatable_label" and I provide as input
       | Input |

--- a/src/Bridge/Transformer/AbstractTransformer.php
+++ b/src/Bridge/Transformer/AbstractTransformer.php
@@ -24,9 +24,14 @@ abstract class AbstractTransformer implements FormToQuestionTransformer
 
     protected function questionFrom(FormInterface $form): string
     {
-        $question = $this->translator->trans(FormUtil::label($form), [], $this->translationDomainFrom($form));
+        $translationDomain = $this->translationDomainFrom($form);
+        $question = $this->translator->trans(FormUtil::label($form), [], $translationDomain);
+        $help = FormUtil::help($form);
+        if ($help !== null) {
+            $help = $this->translator->trans($help, FormUtil::helpTranslationParameters($form), $translationDomain);
+        }
 
-        return $this->formattedQuestion($question, $this->defaultValueFrom($form));
+        return $this->formattedQuestion($question, $this->defaultValueFrom($form), $help);
     }
 
     /**
@@ -55,8 +60,8 @@ abstract class AbstractTransformer implements FormToQuestionTransformer
      * @param mixed $defaultValue
      * @return string
      */
-    protected function formattedQuestion(string $question, $defaultValue): string
+    protected function formattedQuestion(string $question, $defaultValue, ?string $help = null): string
     {
-        return Format::forQuestion($question, $defaultValue);
+        return Format::forQuestion($question, $defaultValue, $help);
     }
 }

--- a/src/Console/Formatter/Format.php
+++ b/src/Console/Formatter/Format.php
@@ -7,16 +7,17 @@ final class Format
     /**
      * @param mixed $defaultValue
      */
-    public static function forQuestion(string $question, $defaultValue): string
+    public static function forQuestion(string $question, $defaultValue, ?string $help = null): string
     {
         $default = $defaultValue ? strtr(
             ' [{defaultValue}]',
             ['{defaultValue}' => (string)$defaultValue]
         ) : '';
-
+        $help = $help !== null ? '<comment>' . $help . '</comment>' . "\n" : '';
         return strtr(
-            '<question>{question}</question>{default}: ',
+            '{help}<question>{question}</question>{default}: ',
             [
+                '{help}' => $help,
                 '{question}' => $question,
                 '{default}' => (string)$default,
             ]

--- a/src/Form/FormUtil.php
+++ b/src/Form/FormUtil.php
@@ -47,6 +47,16 @@ class FormUtil
         return $label;
     }
 
+    public static function help(FormInterface $form): ?string
+    {
+        return $form->getConfig()->getOption('help');
+    }
+
+    public static function helpTranslationParameters(FormInterface $form): array
+    {
+        return $form->getConfig()->getOption('help_translation_parameters');
+    }
+
     public static function isCompound(FormInterface $form): bool
     {
         return $form->getConfig()->getCompound();

--- a/test/Form/HelpMessageType.php
+++ b/test/Form/HelpMessageType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class HelpMessageType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'fieldCompany',
+                TextType::class,
+                [
+                    'label' => 'Company',
+                    'help' => 'help_message_one',
+                    'help_translation_parameters' => [
+                        '%company%' => 'ACME Inc.',
+                    ],
+                    'translation_domain' => 'parent_domain'
+                ]
+            );
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -90,6 +90,14 @@ services:
         tags:
             - { name: console.command }
 
+    help_message_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\HelpMessageType
+            - help_message
+        tags:
+            - { name: console.command }
+
     translatable_label_command:
         class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
         arguments:

--- a/test/translations/parent_domain.en.yml
+++ b/test/translations/parent_domain.en.yml
@@ -1,2 +1,3 @@
 field_one: Parent first field
 field_two: Parent second field
+help_message_one: Restricted to be %company%


### PR DESCRIPTION
This add add [help](https://symfony.com/doc/current/reference/forms/types/form.html#help) and [help_translation_parameters](https://symfony.com/doc/current/reference/forms/types/form.html#help-translation-parameters) Symfony form options to the library.