### PR TITLE
Allow Symfony form "choice_value" option usage

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -53,7 +53,6 @@ class FeatureContext implements Context, SnippetAcceptingContext
 
     /**
      * @Given /^I run the command "([^"]*)" and I provide as input "([^"]*)" with parameters$/
-     * @Given /^parameters"$/
      */
     public function iRunTheCommandAndIProvideAsInputAndParameters($name, $input, TableNode $parameters)
     {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -52,6 +52,21 @@ class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given /^I run the command "([^"]*)" and I provide as input "([^"]*)" with parameters$/
+     * @Given /^parameters"$/
+     */
+    public function iRunTheCommandAndIProvideAsInputAndParameters($name, $input, TableNode $parameters)
+    {
+        $parameters = $parameters->getHash();
+        $parameters = array_combine(
+            array_column($parameters, 'Parameter'),
+            array_column($parameters, 'Value')
+        );
+
+        $this->runCommandWithInteractiveInputAndParameters($name, [$input], $parameters);
+    }
+
+    /**
      * @Given /^I run the command "([^"]*)" and I provide as input "([^"]*)"$/
      */
     public function iRunTheCommandAndIProvideAsInputOneLine($name, $input)
@@ -68,6 +83,12 @@ class FeatureContext implements Context, SnippetAcceptingContext
             StringUtil::trimLines((string) $expectedOutput),
             StringUtil::trimLines($this->getOutput())
         );
+    }
+
+    private function runCommandWithInteractiveInputAndParameters($name, array $inputs, array $parameters)
+    {
+        $this->tester->setInputs($inputs);
+        $this->tester->run(\array_merge(['command' => $name], $parameters), array('interactive' => true, 'decorated' => false));
     }
 
     private function runCommandWithInteractiveInput($name, array $inputs)

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -325,6 +325,30 @@ Feature: It is possible to interactively fill in a form from the CLI
       )
       """
 
+  Scenario: Choice with object options in interactive mode
+    Given I run the command "form:unstringable_choices_with_values" and I provide as input "55-rue-du-faubourg-saint-honoré" with parameters
+      | Parameter   | Value                    |
+      | --address   | 1600-pennsylvania-ave-nw |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Select address [1600-pennsylvania-ave-nw]:
+        [10-downing-street              ] 10 Downing Street
+        [1600-pennsylvania-ave-nw       ] 1600 Pennsylvania Ave NW
+        [55-rue-du-faubourg-saint-honoré] 55 Rue du Faubourg Saint-Honoré
+       >
+      """
+    And the output should contain
+      """
+      Array
+      (
+        [address] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Address Object
+          (
+            [street] => 55 Rue du Faubourg Saint-Honoré
+          )
+      )
+      """
+
   Scenario: Command with default form data
     When I run the command "form:default_value_command" and I provide as input
       | Input |

--- a/features/non-interactive.feature
+++ b/features/non-interactive.feature
@@ -52,3 +52,20 @@ Feature: It is possible to interactively fill in a form from the CLI
     """
     There were form errors.
     """
+
+  Scenario: Choice with object options in non-interactive mode
+    When I run a command non-interactively with parameters
+      | Parameter   | Value                                 |
+      | command     | form:unstringable_choices_with_values |
+      | --address   | 1600-pennsylvania-ave-nw              |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Array
+      (
+        [address] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Address Object
+          (
+            [street] => 1600 Pennsylvania Ave NW
+          )
+      )
+      """

--- a/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
+++ b/src/Bridge/FormFactory/ConsoleFormWithDefaultValuesAndOptionsFactory.php
@@ -3,6 +3,7 @@
 namespace Matthias\SymfonyConsoleForm\Bridge\FormFactory;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -45,7 +46,19 @@ final class ConsoleFormWithDefaultValuesAndOptionsFactory implements ConsoleForm
                 continue;
             }
 
-            $childBuilder->setData($providedValue);
+            $value = $providedValue;
+
+            try {
+                foreach ($childBuilder->getViewTransformers() as $viewTransformer) {
+                    $value = $viewTransformer->reverseTransform($value);
+                }
+                foreach ($childBuilder->getModelTransformers() as $modelTransformer) {
+                    $value = $modelTransformer->reverseTransform($value);
+                }
+            } catch (TransformationFailedException) {
+            }
+
+            $childBuilder->setData($value);
         }
 
         return $formBuilder->getForm();

--- a/test/Form/UnstringableChoicesWithValuesType.php
+++ b/test/Form/UnstringableChoicesWithValuesType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Address;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Demonstrates handling of choice data which does not support conversion to string (Address has no __toString())
+ */
+class UnstringableChoicesWithValuesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('address', ChoiceType::class, [
+                'label' => 'Select address',
+                'choices' => [
+                    new Address('10 Downing Street'),
+                    new Address('1600 Pennsylvania Ave NW'),
+                    new Address('55 Rue du Faubourg Saint-Honoré'),
+                ],
+                'choice_value' => function (Address $address) {
+                    return \strtolower(\str_replace(' ', '-', $address->street));
+                },
+                'choice_label' => function (Address $address) {
+                    return $address->street;
+                },
+                'data' => new Address('10 Downing Street')
+            ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -130,6 +130,14 @@ services:
         tags:
             - { name: console.command }
 
+    unstringable_choices_with_values_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\UnstringableChoicesWithValuesType
+            - unstringable_choices_with_values
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true


### PR DESCRIPTION
At the moment, using `choice_value` option in a `ChoiceType` or `EntityType` results in a fatal error.
I added tests in commit [a86fa6d](https://github.com/matthiasnoback/symfony-console-form/commit/a86fa6d04a476007d29b34de9ab27aba6708ff25) to demonstrate this.
Bug fixed in [e456df7](https://github.com/matthiasnoback/symfony-console-form/commit/e456df73827414dfed67b87f7d2891acc84c8b38) by using form data transformers.