### PR TITLE
Allow non-compound forms and nested forms default values from command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,75 @@ If you add the `--no-interaction` option when running the command, it will submi
 
 If the submitted data is invalid the command will fail.
 
+
+## Using simpler forms with custom names
+
+```php
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;
+
+class TestCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName('form:demo');
+        $this->addOption('custom-option', null, InputOption::VALUE_OPTIONAL, 'Your custom option', 'option1')
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $formHelper = $this->getHelper('form');
+        /** @var FormHelper $formHelper */
+
+        $formData = $formHelper->interactUsingNamedForm('custom-option', ChoiceType::class, $input, $output, [
+            'label' => 'Your label',
+            'help' => 'Additional information to help the interaction',
+            'choices' => [
+                'Default value label' => 'option1',
+                'Another value Label' => 'option2',
+            ]
+        ]);
+
+        // $formData will be "option1" or "option2" and option "--custom-option" will be used as default value
+        ...
+    }
+}
+```
+
+## Nested Forms
+
+If you have a complex compound form, you can define options and reference form children using square brackets:
+
+```php
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;
+
+class TestCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->addOption('user[username]', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('user[email]', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('user[address][street]', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('user[address][city]', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('acceptTerms', null, InputOption::VALUE_OPTIONAL)
+        ;
+    }
+    ...
+}
+```
+
 # TODO
 
 - Maybe: provide a way to submit a form at once, possibly using a JSON-encoded array

--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -364,3 +364,24 @@ Feature: It is possible to interactively fill in a form from the CLI
             [street] => foo
         )
       """
+
+  Scenario: Non-compound form type in interactive mode
+    When I run the command "form:non_compound_color" and I provide as input "blue" with parameters
+      | Parameter | Value  |
+      | --color   | yellow |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Select color [yellow]:
+        [red   ] Red
+        [blue  ] Blue
+        [yellow] Yellow
+      >
+      """
+    And the output should contain
+      """
+      Array
+      (
+          [0] => blue
+      )
+      """

--- a/features/non-interactive.feature
+++ b/features/non-interactive.feature
@@ -83,3 +83,35 @@ Feature: It is possible to interactively fill in a form from the CLI
           [0] => blue
       )
       """
+
+  Scenario: Nested form type in non-interactive mode
+    When I run a command non-interactively with parameters
+      | Parameter               | Value                    |
+      | command                 | form:nested              |
+      | --user[name]            | mario                    |
+      | --user[lastname]        | rossi                    |
+      | --user[password]        | test                     |
+      | --anotherUser[name]     | luigi                    |
+      | --anotherUser[lastname] | verdi                    |
+      | --anotherUser[password] | test2                    |
+      | --color                 | blue                     |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Array
+      (
+          [user] => Array
+          (
+              [name] => mario
+              [lastname] => rossi
+              [password] => test
+          )
+          [anotherUser] => Array
+          (
+              [name] => luigi
+              [lastname] => verdi
+              [password] => test2
+          )
+          [color] => blue
+      )
+      """

--- a/features/non-interactive.feature
+++ b/features/non-interactive.feature
@@ -69,3 +69,17 @@ Feature: It is possible to interactively fill in a form from the CLI
           )
       )
       """
+
+  Scenario: Non-compound form type in non-interactive mode
+    When I run a command non-interactively with parameters
+      | Parameter   | Value                   |
+      | command     | form:non_compound_color |
+      | --color     | blue                    |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Array
+      (
+          [0] => blue
+      )
+      """

--- a/src/Bridge/FormFactory/ConsoleFormFactory.php
+++ b/src/Bridge/FormFactory/ConsoleFormFactory.php
@@ -8,4 +8,6 @@ use Symfony\Component\Form\FormInterface;
 interface ConsoleFormFactory
 {
     public function create(string $formType, InputInterface $input, array $options = []): FormInterface;
+
+    public function createNamed(string $name, string $formType, InputInterface $input, array $options = []): FormInterface;
 }

--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -36,7 +36,8 @@ final class FormHelper extends Helper
      *
      * @return mixed
      */
-    public function interactUsingForm(
+    public function interactUsingNamedForm(
+        ?string $name,
         string $formType,
         InputInterface $input,
         OutputInterface $output,
@@ -46,8 +47,14 @@ final class FormHelper extends Helper
         $validFormFields = [];
 
         do {
-            $form = $this->formFactory->create($formType, $input, $options);
-            $form->setData($data);
+            if ($name === null) {
+                $form = $this->formFactory->create($formType, $input, $options);
+            } else {
+                $form = $this->formFactory->createNamed($name, $formType, $input, $options);
+            }
+            if ($data !== null) {
+                $form->setData($data);
+            }
 
             // if we are rerunning the form for invalid data we don't need the fields that are already valid.
             foreach ($validFormFields as $validFormField) {
@@ -88,6 +95,21 @@ final class FormHelper extends Helper
         } while (!$form->isValid());
 
         return $data;
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return mixed
+     */
+    public function interactUsingForm(
+        string $formType,
+        InputInterface $input,
+        OutputInterface $output,
+        array $options = [],
+        $data = null
+    ) {
+        return $this->interactUsingNamedForm(null, $formType, $input, $output, $options, $data);
     }
 
     protected function noErrorsCanBeFixed(FormErrorIterator $errors): bool

--- a/src/Console/Input/FormBasedInputDefinitionFactory.php
+++ b/src/Console/Input/FormBasedInputDefinitionFactory.php
@@ -35,19 +35,28 @@ class FormBasedInputDefinitionFactory implements InputDefinitionFactory
 
         $inputDefinition = new InputDefinition();
 
+        if (!$form->getConfig()->getCompound()) {
+            $this->addFormToInputDefinition($form->getName(), $form, $inputDefinition);
+        }
+
         foreach ($form->all() as $name => $field) {
-            if (!$this->isFormFieldSupported($field)) {
-                continue;
-            }
-
-            $type = InputOption::VALUE_REQUIRED;
-            $default = $this->resolveDefaultValue($field);
-            $description = FormUtil::label($field);
-
-            $inputDefinition->addOption(new InputOption($name, null, $type, $description, $default));
+            $this->addFormToInputDefinition($name, $field, $inputDefinition);
         }
 
         return $inputDefinition;
+    }
+
+    private function addFormToInputDefinition(string $name, FormInterface $form, InputDefinition $inputDefinition): void
+    {
+        if (!$this->isFormFieldSupported($form)) {
+            return;
+        }
+
+        $type = InputOption::VALUE_REQUIRED;
+        $default = $this->resolveDefaultValue($form);
+        $description = FormUtil::label($form);
+
+        $inputDefinition->addOption(new InputOption($name, null, $type, $description, $default));
     }
 
     private function isFormFieldSupported(FormInterface $field): bool

--- a/src/Form/EventListener/UseInputOptionsAsEventDataEventSubscriber.php
+++ b/src/Form/EventListener/UseInputOptionsAsEventDataEventSubscriber.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyConsoleForm\Form\EventListener;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
@@ -27,14 +28,24 @@ class UseInputOptionsAsEventDataEventSubscriber implements EventSubscriberInterf
         $event->setData($this->convertInputToSubmittedData($input, $event->getForm()));
     }
 
-    private function convertInputToSubmittedData(InputInterface $input, FormInterface $form): array
+    private function convertInputToSubmittedData(InputInterface $input, FormInterface $form, ?string $name = null): mixed
     {
-        $submittedData = [];
-
-        // we don't need to do this recursively, since command options are one-dimensional (or are they?)
-        foreach ($form->all() as $name => $field) {
+        $submittedData = null;
+        if ($form->getConfig()->getCompound()) {
+            $submittedData = [];
+            $repeatedField = $form->getConfig()->getType()->getInnerType() instanceof RepeatedType;
+            foreach ($form->all() as $childName => $field) {
+                if ($repeatedField) {
+                    $submittedData = $this->convertInputToSubmittedData($input, $field, $name ?? $form->getName());
+                } else {
+                    $subName = $name === null ? $childName : $name . '[' . $childName . ']';
+                    $submittedData[$childName] = $this->convertInputToSubmittedData($input, $field, $subName);
+                }
+            }
+        } else {
+            $name = $name ?? $form->getName();
             if ($input->hasOption($name)) {
-                $submittedData[$name] = $input->getOption($name);
+                return $input->getOption($name);
             }
         }
 

--- a/test/Form/NestedType.php
+++ b/test/Form/NestedType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class NestedType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('user', UserType::class)
+            ->add('anotherUser', UserType::class)
+            ->add('color', NonCompoundColorType::class);
+    }
+}

--- a/test/Form/NonCompoundColorType.php
+++ b/test/Form/NonCompoundColorType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NonCompoundColorType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => 'Select color',
+            'choices' => [
+                'Red' => 'red',
+                'Blue' => 'blue',
+                'Yellow' => 'yellow',
+            ],
+            'data' => 'red',
+        ]);
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'color';
+    }
+}

--- a/test/Form/UserType.php
+++ b/test/Form/UserType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class UserType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('lastname', TextType::class)
+            ->add('password', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'invalid_message' => 'The password fields must match.',
+                'first_options' => ['label' => 'Admin Password'],
+                'second_options' => ['label' => 'Repeat Password'],
+            ]);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -146,6 +146,14 @@ services:
         tags:
             - { name: console.command }
 
+    nested_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\NestedType
+            - nested
+        tags:
+            - { name: console.command }
+
 framework:
     form:
         csrf_protection: true

--- a/test/config.yml
+++ b/test/config.yml
@@ -50,6 +50,14 @@ services:
         tags:
             - { name: console.command }
 
+    non_compound_color_command:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\NonCompoundColorType
+            - non_compound_color
+        tags:
+            - { name: console.command }
+
     multi_select_command:
         class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
         arguments:


### PR DESCRIPTION
This pull request allowed `FormHelper` to create named form (just like [Symfony Form Factory](https://github.com/symfony/form/blob/0148f46628efa4c12803768efbdfcd6e0b9ceec3/FormFactory.php#L37) does) and use non compound forms to ask for simpler data.

It also enhance handling of default values from command options by allowing to use square bracket to refer to form children like `--address[street]`.

I updated `README.md` as well.

### Usage of non compound forms and `interactUsingNamedForm`

```php
<?php

use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;

class TestCommand extends Command
{
    protected function configure()
    {
        $this->setName('form:demo');
        $this->addOption('custom-option', null, InputOption::VALUE_OPTIONAL, 'Your custom option', 'option1')
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $formHelper = $this->getHelper('form');
        /** @var FormHelper $formHelper */

        $formData = $formHelper->interactUsingNamedForm('custom-option', ChoiceType::class, $input, $output, [
            'label' => 'Your label',
            'help' => 'Additional information to help the interaction',
            'choices' => [
                'Default value label' => 'option1',
                'Another value Label' => 'option2',
            ]
        ]);

        // $formData will be "option1" or "option2" and option "--custom-option" will be used as default value
        ...
    }
}
```

## Form children default values from command options

```php
<?php

use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Matthias\SymfonyConsoleForm\Console\Helper\FormHelper;

class TestCommand extends Command
{
    protected function configure()
    {
        $this
            ->addOption('user[username]', null, InputOption::VALUE_OPTIONAL)
            ->addOption('user[email]', null, InputOption::VALUE_OPTIONAL)
            ->addOption('user[address][street]', null, InputOption::VALUE_OPTIONAL)
            ->addOption('user[address][city]', null, InputOption::VALUE_OPTIONAL)
            ->addOption('acceptTerms', null, InputOption::VALUE_OPTIONAL)
        ;
    }
    ...
}
```