### PR TITLE
Fix bug with `DataTransformers` and `AbstractTextInputBasedTransformer`

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -399,3 +399,23 @@ Feature: It is possible to interactively fill in a form from the CLI
           [0] => blue
       )
       """
+
+  Scenario: Default value with transformers
+    Given I run the command "form:default_value_with_data_transformers" and I provide as input "Rue du Faubourg Saint-Honoré" with parameters
+      | Parameter   | Value                    |
+      | --street   | pennsylvania-ave-nw |
+    Then the command has finished successfully
+    And the output should contain
+      """
+      Street [pennsylvania-ave-nw]:
+      """
+    And the output should contain
+      """
+      Array
+      (
+        [street] => Matthias\SymfonyConsoleForm\Tests\Form\Data\Street Object
+          (
+            [value] => Rue du Faubourg Saint-Honoré
+          )
+      )
+      """

--- a/src/Bridge/Transformer/AbstractChoiceTransformer.php
+++ b/src/Bridge/Transformer/AbstractChoiceTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
+
+use Matthias\SymfonyConsoleForm\Console\Formatter\Format;
+use Matthias\SymfonyConsoleForm\Form\FormUtil;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+abstract class AbstractChoiceTransformer extends AbstractTransformer
+{
+    protected function defaultValueFrom(FormInterface $form)
+    {
+        $defaultValue = $form->getData();
+        if (is_array($defaultValue)) {
+            $defaultValue = implode(',', $defaultValue);
+        }
+
+        return $defaultValue;
+    }
+}

--- a/src/Bridge/Transformer/AbstractTextInputBasedTransformer.php
+++ b/src/Bridge/Transformer/AbstractTextInputBasedTransformer.php
@@ -13,4 +13,9 @@ abstract class AbstractTextInputBasedTransformer extends AbstractTransformer
     {
         return new Question($this->questionFrom($form), $this->defaultValueFrom($form));
     }
+
+    protected function defaultValueFrom(FormInterface $form)
+    {
+        return $form->getViewData();
+    }
 }

--- a/src/Bridge/Transformer/AbstractTransformer.php
+++ b/src/Bridge/Transformer/AbstractTransformer.php
@@ -22,6 +22,8 @@ abstract class AbstractTransformer implements FormToQuestionTransformer
         $this->translator = $translator;
     }
 
+    abstract protected function defaultValueFrom(FormInterface $form);
+
     protected function questionFrom(FormInterface $form): string
     {
         $translationDomain = $this->translationDomainFrom($form);
@@ -32,19 +34,6 @@ abstract class AbstractTransformer implements FormToQuestionTransformer
         }
 
         return $this->formattedQuestion($question, $this->defaultValueFrom($form), $help);
-    }
-
-    /**
-     * @return mixed
-     */
-    protected function defaultValueFrom(FormInterface $form)
-    {
-        $defaultValue = $form->getData();
-        if (is_array($defaultValue)) {
-            $defaultValue = implode(',', $defaultValue);
-        }
-
-        return $defaultValue;
     }
 
     protected function translationDomainFrom(FormInterface $form): ?string

--- a/src/Bridge/Transformer/CheckboxTransformer.php
+++ b/src/Bridge/Transformer/CheckboxTransformer.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\FormInterface;
 
-final class CheckboxTransformer extends AbstractTransformer
+final class CheckboxTransformer extends AbstractChoiceTransformer
 {
     public function transform(FormInterface $form): Question
     {

--- a/src/Bridge/Transformer/ChoiceTransformer.php
+++ b/src/Bridge/Transformer/ChoiceTransformer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormInterface;
 
-final class ChoiceTransformer extends AbstractTransformer
+final class ChoiceTransformer extends AbstractChoiceTransformer
 {
     public function transform(FormInterface $form): Question
     {

--- a/test/Form/Data/Street.php
+++ b/test/Form/Data/Street.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form\Data;
+
+class Street implements \Stringable
+{
+    public string $value;
+
+    public function __construct(string $street)
+    {
+        $this->value = $street;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/test/Form/DefaultValueWithDataTransformersType.php
+++ b/test/Form/DefaultValueWithDataTransformersType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Address;
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Street;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DefaultValueWithDataTransformersType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('street', StreetType::class, [
+                'label' => 'Street'
+            ]);
+    }
+}

--- a/test/Form/StreetType.php
+++ b/test/Form/StreetType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Matthias\SymfonyConsoleForm\Tests\Form;
+
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Address;
+use Matthias\SymfonyConsoleForm\Tests\Form\Data\Street;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StreetType extends AbstractType implements DataTransformerInterface
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this);
+    }
+
+    public function getParent()
+    {
+        return TextType::class;
+    }
+
+    public function transform(mixed $value)
+    {
+        return (string)$value;
+    }
+
+    public function reverseTransform(mixed $value)
+    {
+        return new Street((string)$value);
+    }
+}

--- a/test/config.yml
+++ b/test/config.yml
@@ -154,6 +154,14 @@ services:
         tags:
             - { name: console.command }
 
+    default_value_with_data_transformers:
+        class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
+        arguments:
+            - Matthias\SymfonyConsoleForm\Tests\Form\DefaultValueWithDataTransformersType
+            - default_value_with_data_transformers
+        tags:
+            - { name: console.command }
+
     nested_command:
         class: Matthias\SymfonyConsoleForm\Tests\Command\PrintFormDataCommand
         arguments:


### PR DESCRIPTION
Fix a bug that leads to a fatal error when using `Symfony\Component\Form\DataTransformerInterface` in FormTypes handled by `\Matthias\SymfonyConsoleForm\Bridge\Transformer\AbstractTextInputBasedTransformer`.