### PR TITLE
fix submitting data from unused options

### DIFF
--- a/src/Console/Helper/FormHelper.php
+++ b/src/Console/Helper/FormHelper.php
@@ -63,7 +63,7 @@ final class FormHelper extends Helper
 
             $submittedData = $this->formInteractor->interactWith($form, $this->getHelperSet(), $input, $output);
 
-            $form->submit($submittedData);
+            $form->submit($submittedData, false);
 
             // save the current data
             $data = $form->getData();

--- a/src/Form/EventListener/UseInputOptionsAsEventDataEventSubscriber.php
+++ b/src/Form/EventListener/UseInputOptionsAsEventDataEventSubscriber.php
@@ -39,8 +39,14 @@ class UseInputOptionsAsEventDataEventSubscriber implements EventSubscriberInterf
                     $submittedData = $this->convertInputToSubmittedData($input, $field, $name ?? $form->getName());
                 } else {
                     $subName = $name === null ? $childName : $name . '[' . $childName . ']';
-                    $submittedData[$childName] = $this->convertInputToSubmittedData($input, $field, $subName);
+                    $subValue = $this->convertInputToSubmittedData($input, $field, $subName);
+                    if ($subValue !== null) {
+                        $submittedData[$childName] = $subValue;
+                    }
                 }
+            }
+            if (empty($submittedData)) {
+                $submittedData = null;
             }
         } else {
             $name = $name ?? $form->getName();


### PR DESCRIPTION
This fixes a bug of submitting `null` values to the form when optional command options are not defined.