### PR TITLE
feat: Add support for file form type

### DIFF
--- a/src/Bridge/Transformer/FileFormTransformer.php
+++ b/src/Bridge/Transformer/FileFormTransformer.php
@@ -1,0 +1,27 @@
+<?php
+declare( strict_types=1 );
+
+namespace Matthias\SymfonyConsoleForm\Bridge\Transformer;
+
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Form\FormInterface;
+
+class FileFormTransformer extends AbstractTransformer
+{
+    public function transform(FormInterface $form): Question
+    {
+        $question = new Question(
+            $this->questionFrom($form),
+            $this->defaultValueFrom($form)
+        );
+        $question->setNormalizer(function($value) {
+            return new \Symfony\Component\HttpFoundation\File\File($value);
+        });
+        return $question;
+    }
+
+    protected function defaultValueFrom(FormInterface $form)
+    {
+        return $form->getViewData();
+    }
+}

--- a/src/Bundle/services.yml
+++ b/src/Bundle/services.yml
@@ -84,6 +84,13 @@ services:
         tags:
             - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\CheckboxType }
 
+    matthias_symfony_console_form.file_transformer:
+        class: Matthias\SymfonyConsoleForm\Bridge\Transformer\FileFormTransformer
+        parent: matthias_symfony_console_form.abstract_transformer
+        public: false
+        tags:
+            - { name: form_to_question_transformer, form_type: Symfony\Component\Form\Extension\Core\Type\FileType }
+
     matthias_symfony_console_form.delegating_interactor:
         class: Matthias\SymfonyConsoleForm\Bridge\Interaction\DelegatingInteractor
         public: false


### PR DESCRIPTION
Add transformer for the `Symfony\Component\Form\Extension\Core\Type\FileType` form type